### PR TITLE
feat: Issue #11 — Name design system Candor, add Storybook introduction page

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,4 +1,4 @@
-<!-- Noto Font Family - Atlas Theme -->
+<!-- Noto Font Family - Candor Design System -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@300;400;500;600;700&family=Noto+Sans+Display:wght@300;400;500;600;700&family=Noto+Sans+Mono:wght@400;500;600&family=Noto+Serif:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -2,3 +2,64 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@300;400;500;600;700&family=Noto+Sans+Display:wght@300;400;500;600;700&family=Noto+Sans+Mono:wght@400;500;600&family=Noto+Serif:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+<style>
+  /* Candor Design System — Docs Typography
+     !important required to override Storybook's emotion CSS-in-JS styles
+     which are injected after static head styles and win the cascade. */
+
+  .sbdocs-wrapper h1,
+  .sbdocs-wrapper h2,
+  .sbdocs-wrapper h3,
+  .sbdocs-wrapper h4,
+  .sbdocs-wrapper h5,
+  .sbdocs-wrapper h6 {
+    font-family: 'Noto Sans Display', 'Noto Sans', system-ui, sans-serif !important;
+    line-height: 1.25 !important;
+    font-weight: 600 !important;
+    letter-spacing: -0.02em !important;
+  }
+
+  .sbdocs-wrapper h1 { font-size: 2.441rem !important; }
+  .sbdocs-wrapper h2 { font-size: 1.953rem !important; }
+  .sbdocs-wrapper h3 { font-size: 1.563rem !important; }
+  .sbdocs-wrapper h4 { font-size: 1.25rem !important; }
+
+  .sbdocs-wrapper p,
+  .sbdocs-wrapper li {
+    font-family: 'Noto Serif', Georgia, serif !important;
+    font-size: 1rem !important;
+    line-height: 1.75 !important;
+  }
+
+  .sbdocs-wrapper strong {
+    font-family: 'Noto Sans', system-ui, sans-serif !important;
+    font-weight: 600 !important;
+  }
+
+  .sbdocs-wrapper code,
+  .sbdocs-wrapper pre {
+    font-family: 'Noto Sans Mono', 'Roboto Mono', monospace !important;
+    font-size: 0.9rem !important;
+  }
+
+  .sbdocs-wrapper table {
+    font-family: 'Noto Sans', system-ui, sans-serif !important;
+    font-size: 0.9rem !important;
+    line-height: 1.5 !important;
+    border-collapse: collapse;
+    width: 100%;
+  }
+
+  .sbdocs-wrapper th {
+    font-weight: 600 !important;
+    text-align: left;
+    padding: 0.5rem 1rem;
+    border-bottom: 2px solid #e0e0e0;
+  }
+
+  .sbdocs-wrapper td {
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid #e0e0e0;
+  }
+</style>

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -2,6 +2,11 @@ import type { Preview } from '@storybook/angular';
 
 const preview: Preview = {
   parameters: {
+    options: {
+      storySort: {
+        order: ['Introduction', 'Design Tokens', 'Typography', 'Button', 'Form', 'Examples'],
+      },
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/docs/CANDOR-DESIGN-SYSTEM.md
+++ b/docs/CANDOR-DESIGN-SYSTEM.md
@@ -1,12 +1,12 @@
-# Atlas Design System Documentation
+# Candor Design System Documentation
 
-**Version:** 1.0.0  
-**Date:** December 5, 2025  
-**Branch:** `task-1-atlas-look-and-feel`
+**Version:** 1.0.0
+**Date:** March 16, 2026
+**Branch:** `issue-11-design-system-completion`
 
 ## Executive Summary
 
-The Atlas Design System is a modern, professional, yet approachable design language created for a map atlas application with global localization requirements. The system balances cartographic tradition with contemporary digital design, emphasizing accessibility, readability, and multi-language support.
+The Candor Design System is a modern, professional, yet approachable design language emphasizing accessibility, readability, and multi-language support. The system balances cartographic tradition with contemporary digital design, grounded in the principle that good design tells the truth about what works.
 
 ---
 
@@ -100,7 +100,7 @@ Each primary color includes hover and active states with reduced lightness:
 ## Typography System
 
 ### Philosophy
-The Noto font family provides comprehensive global language support while maintaining visual consistency across Latin, Cyrillic, CJK, Arabic, and 800+ other scripts. This ensures the Atlas application can be localized without compromising typographic quality.
+The Noto font family provides comprehensive global language support while maintaining visual consistency across Latin, Cyrillic, CJK, Arabic, and 800+ other scripts. This ensures the Candor application can be localized without compromising typographic quality.
 
 ### Font Families
 
@@ -215,7 +215,7 @@ All color combinations have been validated using APCA, which provides more accur
 
 ```
 src/design-tokens/
-├── colors.scss         # OKLCH color definitions (Atlas theme)
+├── colors.scss         # OKLCH color definitions (Candor theme)
 ├── typography.scss     # Noto font system
 ├── spacing.scss        # 8px grid system
 └── index.scss         # Token aggregation

--- a/src/Introduction.mdx
+++ b/src/Introduction.mdx
@@ -1,0 +1,92 @@
+# Candor Design System
+
+**Version 1.0 · March 2026**
+
+Candor is a design system built on a single premise: *good design tells the truth about what works.* Not what passes a checklist. Not what looks compliant on paper. What actually works — for the widest range of people, in the widest range of contexts.
+
+The name comes from a direct line through the work. Accessibility standards that produce false passes, safety benchmarks optimized for clearing thresholds rather than catching failures, governance processes that accept input from affected populations without giving them a seat — these are all failures of candor. A design system named Candor is a commitment to close that gap.
+
+---
+
+## Design Principles
+
+### Accessibility is the baseline, not the finish line
+WCAG compliance is where we start. Outcome-based validation — real color science, real user impact — is where we go from there. Every token, every component, every contrast decision is validated using OKCA — a contrast algorithm that addresses known issues with WCAG's luminance math while prioritizing WCAG compatibility and coherence with OKLCH, so designers can directly equate their color pickers and tonal ramps with accessibility outcomes.
+
+### Perceptual truth over nominal correctness
+Colors are defined in OKLCH — a perceptually uniform color space where equal numeric changes produce equal perceived changes. This isn't an aesthetic preference; it's what makes programmatic accessibility validation reliable.
+
+### Typography as cognitive infrastructure
+The typographic system is organized around two human modes: **execution** (task completion, navigation, scanning) and **interpretation** (reading, reflecting, conversing). Font choices aren't decorative — they signal which mode a surface is designed for.
+
+### No hard-coded values, ever
+All styling flows from design tokens. Components never reach past their token layer. This isn't a rule for tidiness — it's what makes the system auditable, adjustable, and honest about its own decisions.
+
+---
+
+## Typographic System
+
+Candor uses a four-voice typographic system aligned to cognitive mode and content type.
+
+<table>
+  <thead>
+    <tr><th>Voice</th><th>Typeface</th><th>Mode</th><th>Primary Use</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Structural Sans</td><td>Roboto Flex</td><td>Execution</td><td>Navigation, UI scaffolding, data-dense components</td></tr>
+    <tr><td>Technical Mono</td><td>Roboto Mono</td><td>Execution</td><td>Code, logs, terminal environments</td></tr>
+    <tr><td>Accessibility Anchor</td><td>Atkinson Hyperlegible</td><td>Execution</td><td>Critical UI, labels, high-contrast environments</td></tr>
+    <tr><td>Human-Centered</td><td>Noto Sans / Noto Serif</td><td>Interpretation</td><td>Long-form reading, conversational UI, multilingual content</td></tr>
+  </tbody>
+</table>
+
+**Scale:** Major Third ratio (1.25×) from a 1rem (16px) base.
+**Grid:** 8px spacing unit throughout.
+
+---
+
+## Color Philosophy
+
+The palette draws from personal brand anchors — deep navy (`#082840`), warm burgundy (`#5F2B48`), and azure (`#1493FB`) — extended into a full OKLCH token system. Every color in the system has a documented contrast validation against its intended pairings.
+
+Semantic colors follow strict outcome-based thresholds:
+- **APCA ≥ 60** for body text
+- **APCA ≥ 45** for UI elements and large text
+- **WCAG 2.x AA** maintained as a floor, not a ceiling
+
+---
+
+## Contrast Methods
+
+Candor validates color pairs across multiple algorithms, acknowledging that no single method captures the full picture:
+
+<table>
+  <thead>
+    <tr><th>Method</th><th>Standard</th><th>Notes</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>WCAG2</td><td>WCAG 2.x</td><td>Regulatory floor; luminance ratio</td></tr>
+    <tr><td>APCA</td><td>WCAG 3 (draft)</td><td>Perceptual contrast; polarity-aware</td></tr>
+    <tr><td>BPCA</td><td>Bridge-PCA</td><td>APCA-compatible; backwards-bridge</td></tr>
+    <tr><td>OKCA / PCA</td><td>Internal</td><td>Primary validation method; WCAG-compatible, OKLCH-coherent</td></tr>
+    <tr><td>DeltaE</td><td>Perceptual distance</td><td>Supplementary; different scale</td></tr>
+  </tbody>
+</table>
+
+---
+
+## What's Here
+
+Use the sidebar to explore components by category:
+
+- **Design Tokens** — Colors, typography scale, spacing
+- **Typography** — Heading hierarchy, body text, accessible text, article layout
+- **Button** — Primary, secondary, tertiary, ghost variants
+- **Form** — Input, checkbox, radio
+- **Examples** — Composed patterns: card, form
+
+Every component story includes accessibility annotations and contrast documentation where relevant.
+
+---
+
+*Candor is a personal design system by John Z. Rioflorido — design technologist and ethical systems designer, working at the intersection of cartography, accessibility, and AI safety.*

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <title>Atlas Design System</title>
+        <title>Candor Design System</title>
         <base href="/" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" type="image/svg+xml" href="favicon.svg" />


### PR DESCRIPTION
## Summary

- Renames the design system from Atlas to **Candor** across all files
- Adds `src/Introduction.mdx` as the Storybook landing page with a full design brief covering the name rationale, design principles, typographic system, color philosophy, OKCA contrast methodology, and component navigation
- Configures sidebar sort order so Introduction appears first
- Applies Candor's own typography (Noto Serif for body, Noto Sans Display for headings) to Storybook docs pages

Closes #11

## Test plan

- [ ] Open Storybook — Introduction should be the first item in the sidebar and load by default
- [ ] Verify body text renders in Noto Serif, headings in Noto Sans Display
- [ ] Verify tables render correctly in the Introduction page
- [ ] Confirm no console errors on the Introduction page

🤖 Generated with [Claude Code](https://claude.com/claude-code)