### PR TITLE
fix: Article projected content styles, blockquote tokens, ng-deep guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,34 @@ export const Default: Story = {
 - Built-in control flow works correctly with Zone.js enabled
 - When refactoring existing code, always convert old directives to built-in syntax
 
+### View Encapsulation and Projected Content
+
+**NEVER use `::ng-deep`** — it is deprecated by the Angular team and will be removed.
+
+When a component needs to style projected content (i.e., elements passed via `<ng-content>` or as string literals in stories), use `ViewEncapsulation.None` instead:
+
+```typescript
+import { Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'app-article',
+  encapsulation: ViewEncapsulation.None,
+  // ...
+})
+```
+
+With `ViewEncapsulation.None`, Angular does not add scoping attributes, so descendant selectors in the component's SCSS reach projected elements. Scope the styles manually using the host element's class (set via the `host` binding) to prevent leakage:
+
+```scss
+// article.component.scss — scoped via host class, no ::ng-deep needed
+.article {
+  h1, h2, h3, h4 { ... }
+  p { ... }
+}
+```
+
+**Why `::ng-deep` fails for projected content**: Angular's emulated encapsulation adds a unique attribute (e.g. `_ngcontent-xxx`) to elements in the component's own template. Elements projected from outside (string literals in stories, or content from a parent template) receive the *parent's* scoping attribute, not the component's — so `:host h1 { }` never matches them. `ViewEncapsulation.None` sidesteps this entirely.
+
 ## Common Pitfalls
 
 1. **Don't hard-code colors**: Always use design tokens
@@ -231,6 +259,7 @@ export const Default: Story = {
 3. **Don't skip accessibility validation**: Check contrast before finalizing
 4. **Don't create components without stories**: Every component needs a story
 5. **Don't modify node_modules**: This is obvious but worth stating
+6. **Never use `::ng-deep`**: It is deprecated. Use `ViewEncapsulation.None` with a host class for scoping when styling projected content (see "View Encapsulation and Projected Content" above)
 
 ## Testing Strategy
 

--- a/src/app/components/typography/article/article.component.scss
+++ b/src/app/components/typography/article/article.component.scss
@@ -1,4 +1,4 @@
-:host {
+.article {
     display: block;
     max-width: 65ch;
     font-size: var(--font-size-lg);
@@ -40,12 +40,12 @@
 
     // Blockquote
     blockquote {
-        border-left: var(--border-width-thick) solid var(--color-action-secondary);
+        border-left: var(--border-width-thick) solid var(--color-blockquote-border);
         margin: var(--spacing-lg) 0;
         padding: var(--spacing-sm) var(--spacing-md);
         font-style: italic;
-        color: var(--color-text-subtle);
-        background-color: var(--color-bg-surface);
+        color: var(--color-blockquote-text);
+        background-color: var(--color-blockquote-bg);
         border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
     }
 

--- a/src/app/components/typography/article/article.component.ts
+++ b/src/app/components/typography/article/article.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ViewEncapsulation } from '@angular/core';
 
 type ArticleFont = 'reading' | 'serif';
 
@@ -7,6 +7,7 @@ type ArticleFont = 'reading' | 'serif';
   standalone: true,
   template: `<ng-content></ng-content>`,
   styleUrls: ['./article.component.scss'],
+  encapsulation: ViewEncapsulation.None,
   host: {
     '[class]': '"article article--font-" + font',
   },

--- a/src/design-tokens/semantics.scss
+++ b/src/design-tokens/semantics.scss
@@ -9,11 +9,12 @@
     --color-bg-inverse: var(--navy-800);
 
     // ─── Colors: Text ──────────────────────────────────────────────────────────
-    --color-text-default:   var(--gray-700);  // 12.6:1 on --color-bg-page ✅
-    --color-text-subtle:    var(--gray-500);  //  4.5:1 on --color-bg-page ✅
-    --color-text-disabled:  var(--gray-400);
-    --color-text-inverse:   var(--gray-0);
-    --color-text-on-action: var(--gray-0);    // white text on primary/secondary buttons
+    --color-text-default:          var(--gray-700);  // 12.6:1 on --color-bg-page ✅
+    --color-text-subtle:           var(--gray-500);  //  4.5:1 on --color-bg-page ✅
+    --color-text-subtle-on-surface: var(--gray-600); //  5.4:1 on --color-bg-surface ✅  3.4:1 gap closed
+    --color-text-disabled:         var(--gray-400);
+    --color-text-inverse:          var(--gray-0);
+    --color-text-on-action:        var(--gray-0);    // white text on primary/secondary buttons
 
     // ─── Colors: Borders ───────────────────────────────────────────────────────
     --color-border-default: var(--gray-200);
@@ -45,6 +46,11 @@
     // purple-500 is the brand original (#6969F7) — decorative use only.
     --color-highlight:            var(--purple-600); // accessible ✅
     --color-highlight-decorative: var(--purple-500); // original brand color
+
+    // ─── Colors: Blockquote ────────────────────────────────────────────────────
+    --color-blockquote-bg:     var(--color-bg-surface);
+    --color-blockquote-border: var(--color-action-secondary);
+    --color-blockquote-text:   var(--color-text-subtle-on-surface); // 5.4:1 on --color-blockquote-bg ✅
 
     // ─── Colors: Focus ─────────────────────────────────────────────────────────
     --color-focus: var(--azure-400); // high-visibility ring on dark/white backgrounds


### PR DESCRIPTION
## Summary

- **Article component**: Switched from `ViewEncapsulation.Emulated` (`:host`) to `ViewEncapsulation.None` with `.article` class scoping — projected content from string literals in stories was not receiving component styles because Angular's emulated encapsulation only adds scoping attributes to elements in the component's own template, not to projected elements
- **Blockquote contrast**: Added `--color-text-subtle-on-surface` (gray-600, 5.4:1 on surface bg) to close the contrast gap where `--color-text-subtle` (gray-500) only reaches 3.4:1 on `--color-bg-surface`; added a `--color-blockquote-*` semantic token group as a single validated source of truth for all future blockquote usage
- **CLAUDE.md**: Documented `ViewEncapsulation.None` as the correct pattern for projected content and added a hard prohibition on `::ng-deep` (deprecated by Angular team) to Common Pitfalls

## Test plan

- [ ] Open Storybook → Typography/Article — confirm headings, paragraphs, lists, blockquotes, code blocks all render with correct styles
- [ ] Confirm blockquote text has sufficient contrast against the surface background
- [ ] Confirm no style leakage outside `app-article` elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)