### PR TITLE
chore: add release scripts, CHANGELOG, and release workflow docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,22 @@
+# Candor — Project Instructions (Claude-specific)
+
+## Versioning & Release
+
+Candor follows semver. The token package is stable at 1.0.0 — treat MINOR as additive changes, MAJOR as breaking changes to token names or structure.
+
+### Release workflow
+
+1. Update `CHANGELOG.md` with the changes under a new `[X.Y.Z] - YYYY-MM-DD` heading
+2. Run the appropriate release script from `main`:
+   - `npm run release:patch` — bug fixes, doc corrections
+   - `npm run release:minor` — new tokens, non-breaking additions
+   - `npm run release:major` — renamed/removed tokens, breaking changes
+3. This bumps `package.json`, commits, tags `vX.Y.Z`, and pushes the tag
+4. GitHub Actions (`draft-release.yml`) creates a draft release with auto-generated notes
+5. Review and edit the draft on GitHub, then click **Publish release**
+6. GitHub Actions (`publish.yml`) publishes to npm via OIDC trusted publishing — no token needed
+
+### Never do manually
+- Don't `git tag` by hand — `npm version` handles it
+- Don't `npm publish` directly after the bootstrap — trusted publishing takes over
+- Don't push a tag from a branch other than `main` — `draft-release.yml` enforces this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-03-23
+
+### Added
+- Initial public release of `@candor-design/tokens`
+- CSS custom properties for color (OKLCH), typography, spacing, and shape tokens
+- Dark mode support via `prefers-color-scheme` and `[data-theme]` attribute
+- Minified CSS and JSON exports alongside the full stylesheet
+- GitHub Actions publish pipeline with OIDC trusted publishing (no `NPM_TOKEN` required)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "build-storybook": "ng run design-system-playground:build-storybook",
     "test:playwright": "playwright test",
     "test:playwright:ui": "playwright test --ui",
-    "build:tokens": "node scripts/build-tokens.js"
+    "build:tokens": "node scripts/build-tokens.js",
+    "release:patch": "npm version patch && git push origin main --follow-tags",
+    "release:minor": "npm version minor && git push origin main --follow-tags",
+    "release:major": "npm version major && git push origin main --follow-tags"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Adds `release:patch`, `release:minor`, `release:major` npm scripts — one command handles version bump, commit, tag, and push to trigger the CI publish pipeline
- Adds `CHANGELOG.md` (Keep a Changelog format) with the 1.0.0 entry
- Adds `.claude/CLAUDE.md` documenting the release workflow so it's always available in context

## Test plan

- [ ] Verify `npm run release:patch` bumps version, commits, tags, and pushes on `main`
- [ ] Confirm draft release is created by CI after tag push
- [ ] Confirm npm publish triggers after release is published on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)