### PR TITLE
fix(examples): mobile-friendly Example stories + Tabs scroll affordance

### DIFF
--- a/src/app/components/alert/alert.component.scss
+++ b/src/app/components/alert/alert.component.scss
@@ -69,6 +69,7 @@
     font-size: var(--font-size-md); // 16px — see title comment above
     line-height: var(--line-height-normal);
     letter-spacing: 0.02em;
+    overflow-wrap: break-word;
   }
 
   // Dismiss

--- a/src/app/components/tabs/tabs.component.scss
+++ b/src/app/components/tabs/tabs.component.scss
@@ -3,10 +3,40 @@
 }
 
 .tabs {
+  &__list-wrapper {
+    position: relative;
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      width: 6rem;
+      pointer-events: none;
+      z-index: 1;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+    }
+
+    &::before {
+      left: 0;
+      background: linear-gradient(to right, var(--color-bg-page), transparent);
+    }
+
+    &::after {
+      right: 0;
+      background: linear-gradient(to left, var(--color-bg-page), transparent);
+    }
+  }
+
   &__list {
     display: flex;
     flex-direction: row;
     border-bottom: var(--border-width-thin) solid var(--color-border-default);
+    overflow-x: auto;
+    scrollbar-width: none;
+    &::-webkit-scrollbar { display: none; }
   }
 
   &__tab {
@@ -52,6 +82,11 @@
     flex-direction: row;
     align-items: flex-start;
 
+    .tabs__list-wrapper::before,
+    .tabs__list-wrapper::after {
+      display: none;
+    }
+
     .tabs__list {
       flex-direction: column;
       flex-shrink: 0;
@@ -83,6 +118,11 @@
 
   // Inverse theme — for dark headers and surfaces
   &--inverse {
+    .tabs__list-wrapper {
+      &::before { background: linear-gradient(to right, var(--color-bg-inverse), transparent); }
+      &::after  { background: linear-gradient(to left,  var(--color-bg-inverse), transparent); }
+    }
+
     .tabs__list {
       border-bottom-color: var(--color-border-on-inverse);
       background-color: var(--color-bg-inverse);
@@ -103,3 +143,6 @@
     }
   }
 }
+
+:host(.tabs--can-scroll-left) .tabs__list-wrapper::before { opacity: 1; }
+:host(.tabs--can-scroll-right) .tabs__list-wrapper::after { opacity: 1; }

--- a/src/app/components/tabs/tabs.component.stories.ts
+++ b/src/app/components/tabs/tabs.component.stories.ts
@@ -138,6 +138,34 @@ export const VerticalSidebar: Story = {
   }),
 };
 
+export const ManyTabs: Story = {
+  name: 'Pattern: Many tabs (scroll affordance)',
+  parameters: {
+    docs: {
+      description: {
+        story: `When more tabs exist than the container can display, the tab list scrolls horizontally.
+A gradient fade at the trailing edge signals that additional tabs are available — the partially-visible
+tab label is the affordance. The fade transitions out once the last tab scrolls into full view,
+and a mirrored left-edge fade appears when the list has been scrolled past the first tab.`,
+      },
+    },
+  },
+  render: () => ({
+    template: `
+      <div style="max-width: 320px;">
+        <app-tabs ariaLabel="Dashboard sections">
+          <app-tab-panel tabId="overview"      label="Overview">      <p>High-level metrics and recent activity.</p>      </app-tab-panel>
+          <app-tab-panel tabId="analytics"     label="Analytics">     <p>Traffic, conversion, and engagement data.</p>    </app-tab-panel>
+          <app-tab-panel tabId="reports"       label="Reports">       <p>Scheduled and on-demand report archive.</p>      </app-tab-panel>
+          <app-tab-panel tabId="notifications" label="Notifications"> <p>Alerts, mentions, and system messages.</p>       </app-tab-panel>
+          <app-tab-panel tabId="integrations"  label="Integrations">  <p>Connected apps, webhooks, and API keys.</p>      </app-tab-panel>
+          <app-tab-panel tabId="settings"      label="Settings">      <p>Account preferences and access controls.</p>    </app-tab-panel>
+        </app-tabs>
+      </div>
+    `,
+  }),
+};
+
 export const Controlled: Story = {
   render: () => ({
     props: {

--- a/src/app/components/tabs/tabs.component.ts
+++ b/src/app/components/tabs/tabs.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterContentInit,
+  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   contentChildren,
@@ -9,7 +10,10 @@ import {
   inject,
   input,
   model,
+  OnDestroy,
   output,
+  signal,
+  viewChild,
 } from '@angular/core';
 import { TabPanelComponent } from './tab-panel.component';
 
@@ -17,22 +21,28 @@ import { TabPanelComponent } from './tab-panel.component';
   selector: 'app-tabs',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[class.tabs--can-scroll-left]': 'canScrollLeft()',
+    '[class.tabs--can-scroll-right]': 'canScrollRight()',
+  },
   template: `
     <div [class]="'tabs' + (theme() === 'inverse' ? ' tabs--inverse' : '') + (orientation() === 'vertical' ? ' tabs--vertical' : '')">
-      <div class="tabs__list" role="tablist" [attr.aria-label]="ariaLabel() || null" [attr.aria-orientation]="orientation()">
-        @for (panel of panels(); track panel.tabId(); let i = $index) {
-          <button
-            class="tabs__tab"
-            role="tab"
-            [id]="'tab-' + panel.tabId()"
-            [attr.aria-selected]="panel.tabId() === activeId()"
-            [attr.aria-controls]="'panel-' + panel.tabId()"
-            [attr.aria-setsize]="panels().length"
-            [attr.aria-posinset]="i + 1"
-            [tabindex]="panel.tabId() === activeId() ? 0 : -1"
-            (click)="activate(panel.tabId())"
-          >{{ panel.label() }}</button>
-        }
+      <div class="tabs__list-wrapper">
+        <div class="tabs__list" role="tablist" #tabList [attr.aria-label]="ariaLabel() || null" [attr.aria-orientation]="orientation()">
+          @for (panel of panels(); track panel.tabId(); let i = $index) {
+            <button
+              class="tabs__tab"
+              role="tab"
+              [id]="'tab-' + panel.tabId()"
+              [attr.aria-selected]="panel.tabId() === activeId()"
+              [attr.aria-controls]="'panel-' + panel.tabId()"
+              [attr.aria-setsize]="panels().length"
+              [attr.aria-posinset]="i + 1"
+              [tabindex]="panel.tabId() === activeId() ? 0 : -1"
+              (click)="activate(panel.tabId())"
+            >{{ panel.label() }}</button>
+          }
+        </div>
       </div>
       <div class="tabs__panels">
         <ng-content></ng-content>
@@ -41,7 +51,7 @@ import { TabPanelComponent } from './tab-panel.component';
   `,
   styleUrls: ['./tabs.component.scss']
 })
-export class TabsComponent implements AfterContentInit {
+export class TabsComponent implements AfterContentInit, OnDestroy {
   panels = contentChildren(TabPanelComponent);
 
   ariaLabel = input('');
@@ -54,6 +64,11 @@ export class TabsComponent implements AfterContentInit {
   activeId = model('');
   tabChange = output<string>();
 
+  canScrollLeft = signal(false);
+  canScrollRight = signal(false);
+
+  private tabListRef = viewChild<ElementRef<HTMLElement>>('tabList');
+  private scrollObserver?: ResizeObserver;
   private el = inject(ElementRef);
 
   constructor() {
@@ -62,6 +77,28 @@ export class TabsComponent implements AfterContentInit {
       const id = this.activeId();
       this.panels().forEach(p => p.setActive(p.tabId() === id));
     });
+
+    afterNextRender(() => {
+      const el = this.tabListRef()?.nativeElement;
+      if (!el) return;
+      const update = () => {
+        if (this.orientation() === 'vertical') {
+          this.canScrollLeft.set(false);
+          this.canScrollRight.set(false);
+          return;
+        }
+        this.canScrollLeft.set(el.scrollLeft > 0);
+        this.canScrollRight.set(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+      };
+      el.addEventListener('scroll', update, { passive: true });
+      this.scrollObserver = new ResizeObserver(update);
+      this.scrollObserver.observe(el);
+      update();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.scrollObserver?.disconnect();
   }
 
   ngAfterContentInit(): void {

--- a/src/app/examples/card-example.stories.ts
+++ b/src/app/examples/card-example.stories.ts
@@ -39,7 +39,7 @@ type Story = StoryObj;
 export const ProductCard: Story = {
   render: () => ({
     template: `
-      <div style="max-width: 350px; border: 1px solid var(--color-border-default); border-radius: 8px; overflow: hidden;">
+      <div style="padding: 1rem; max-width: 100%;"><div style="max-width: 350px; border: 1px solid var(--color-border-default); border-radius: 8px; overflow: hidden;">
         <div style="width: 100%; height: 200px; background: linear-gradient(135deg, oklch(0.75 0.15 250), oklch(0.60 0.18 250));"></div>
 
         <div style="padding: 1.5rem;">
@@ -83,7 +83,7 @@ export const ProductCard: Story = {
             ]"></app-menu>
           </div>
         </div>
-      </div>
+      </div></div>
     `,
   }),
 };
@@ -91,7 +91,7 @@ export const ProductCard: Story = {
 export const ArticleCard: Story = {
   render: () => ({
     template: `
-      <div style="max-width: 400px; border: 1px solid var(--color-border-default); border-radius: 8px; overflow: hidden;">
+      <div style="padding: 1rem; max-width: 100%;"><div style="max-width: 400px; border: 1px solid var(--color-border-default); border-radius: 8px; overflow: hidden;">
         <div style="width: 100%; height: 180px; background: linear-gradient(135deg, oklch(0.70 0.12 180), oklch(0.55 0.15 200));"></div>
 
         <div style="padding: 1.5rem;">
@@ -124,7 +124,7 @@ export const ArticleCard: Story = {
             </app-tooltip>
           </div>
         </div>
-      </div>
+      </div></div>
     `,
   }),
 };
@@ -132,7 +132,7 @@ export const ArticleCard: Story = {
 export const ProfileCard: Story = {
   render: () => ({
     template: `
-      <div style="max-width: 300px; border: 1px solid var(--color-border-default); border-radius: 8px; text-align: center; padding: 2rem;">
+      <div style="padding: 1rem; max-width: 100%;"><div style="max-width: 300px; border: 1px solid var(--color-border-default); border-radius: 8px; text-align: center; padding: 2rem;">
         <div style="width: 100px; height: 100px; margin: 0 auto 1rem; border-radius: 50%; background: linear-gradient(135deg, oklch(0.65 0.18 320), oklch(0.50 0.20 280));"></div>
 
         <app-heading [level]="3" style="margin-bottom: 0.25rem;">
@@ -182,7 +182,7 @@ export const ProfileCard: Story = {
             Message
           </app-button>
         </div>
-      </div>
+      </div></div>
     `,
   }),
 };
@@ -195,7 +195,7 @@ export const CardGrid: Story = {
           Featured Products
         </app-heading>
 
-        <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.5rem;">
+        <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(min(100%, 300px), 1fr)); gap: 1.5rem;">
           <!-- Card 1 -->
           <div style="border: 1px solid var(--color-border-default); border-radius: 8px; overflow: hidden;">
             <div style="width: 100%; height: 150px; background: linear-gradient(135deg, oklch(0.75 0.15 250), oklch(0.60 0.18 250));"></div>

--- a/src/app/examples/chat-example.stories.ts
+++ b/src/app/examples/chat-example.stories.ts
@@ -46,6 +46,9 @@ export default meta;
 type Story = StoryObj;
 
 export const AIChatInterface: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
   render: () => ({
     props: {
       navItems: [
@@ -54,8 +57,17 @@ export const AIChatInterface: Story = {
         { label: 'API', href: '#' },
       ],
     },
+    styles: [`
+      :host { display: block; height: 100vh; overflow: hidden; }
+      @media (max-width: 600px) {
+        .chat-sidebar { display: none !important; }
+        app-navigation { display: none !important; }
+        .chat-messages { padding: 1rem !important; }
+        .chat-input-area { padding: 0.75rem 1rem 1rem !important; }
+      }
+    `],
     template: `
-      <div style="min-height: 100vh; background: var(--color-bg-page); display: flex; flex-direction: column;">
+      <div style="position: fixed; inset: 0; background: var(--color-bg-page); display: flex; flex-direction: column; overflow: hidden;">
 
         <!-- Navigation -->
         <app-navigation
@@ -65,10 +77,11 @@ export const AIChatInterface: Story = {
         </app-navigation>
 
         <!-- Chat layout -->
-        <div style="flex: 1; display: flex;">
+        <div style="flex: 1; display: flex; min-height: 0;">
 
           <!-- Sidebar -->
           <aside
+            class="chat-sidebar"
             aria-label="Conversation history"
             style="
               width: 220px;
@@ -138,7 +151,7 @@ export const AIChatInterface: Story = {
           </aside>
 
           <!-- Main chat column -->
-          <div style="flex: 1; display: flex; flex-direction: column; min-width: 0;">
+          <div style="flex: 1; display: flex; flex-direction: column; min-width: 0; min-height: 0;">
 
             <!-- Chat header -->
             <header style="
@@ -161,10 +174,12 @@ export const AIChatInterface: Story = {
             <!-- Message thread -->
             <div
               role="log"
+              class="chat-messages"
               aria-label="Conversation"
               aria-live="polite"
               style="
                 flex: 1;
+                overflow-y: auto;
                 padding: 1.5rem;
                 display: flex;
                 flex-direction: column;
@@ -364,7 +379,7 @@ export const AIChatInterface: Story = {
             </div>
 
             <!-- Compose area -->
-            <div style="
+            <div class="chat-input-area" style="
               padding: 1rem 1.5rem 1.25rem;
               border-top: 1px solid var(--color-border-default);
               flex-shrink: 0;

--- a/src/app/examples/color-iterator-example.stories.ts
+++ b/src/app/examples/color-iterator-example.stories.ts
@@ -155,7 +155,7 @@ export const ColorPairIterator: Story = {
           </header>
 
           <!-- Two-column layout -->
-          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; align-items: start;">
+          <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 340px), 1fr)); gap: 1.25rem; align-items: start;">
 
             <!-- ── Left column: controls ── -->
             <div style="display: flex; flex-direction: column; gap: 1rem;">

--- a/src/app/examples/data-example.stories.ts
+++ b/src/app/examples/data-example.stories.ts
@@ -68,7 +68,7 @@ export const FilterableTable: Story = {
       currentPage: 3,
     },
     template: `
-      <div style="padding: 2rem; max-width: 900px;">
+      <div style="padding: clamp(1rem, 4vw, 2rem); max-width: 900px;">
 
         <!-- Page header -->
         <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 1.5rem; gap: 1rem; flex-wrap: wrap;">
@@ -76,10 +76,10 @@ export const FilterableTable: Story = {
             <app-heading [level]="1" style="margin-bottom: 0.25rem;">Submissions</app-heading>
             <app-text variant="body" style="color: var(--color-text-subtle);">247 results · Page 3 of 25</app-text>
           </div>
-          <div style="display: flex; align-items: flex-start; gap: 0.75rem; padding-top: 6px;">
+          <div style="display: flex; align-items: flex-start; gap: 0.75rem; padding-top: 6px; padding-right: 0.5rem;">
             <app-input
               placeholder="Search submissions..."
-              style="width: 220px;">
+              style="flex: 1; min-width: 120px; max-width: 220px;">
             </app-input>
             <div style="position: relative; display: inline-flex; align-items: center;">
               <app-button variant="secondary" (clicked)="drawerOpen = true">
@@ -89,7 +89,7 @@ export const FilterableTable: Story = {
               <!-- Active filter badge -->
               <app-badge
                 variant="primary"
-                style="position: absolute; top: -6px; right: -6px; min-width: 1.25rem; text-align: center;"
+                style="position: absolute; top: -6px; right: 0; min-width: 1.25rem; text-align: center;"
                 aria-label="3 active filters">
                 3
               </app-badge>
@@ -98,7 +98,8 @@ export const FilterableTable: Story = {
         </div>
 
         <!-- Results table -->
-        <app-table style="display: block; margin-bottom: 1.5rem;">
+        <div style="overflow-x: auto; margin-bottom: 1.5rem;">
+        <app-table style="display: block;">
           <table>
             <thead>
               <tr>
@@ -169,6 +170,7 @@ export const FilterableTable: Story = {
             </tbody>
           </table>
         </app-table>
+        </div>
 
         <!-- Pagination -->
         <app-pagination

--- a/src/app/examples/form-example.stories.ts
+++ b/src/app/examples/form-example.stories.ts
@@ -197,7 +197,7 @@ export const RegistrationForm: Story = {
         </app-text>
 
         <form style="display: flex; flex-direction: column; gap: 1.5rem;">
-          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+          <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr)); gap: 1rem;">
             <app-input
               [label]="'First Name'"
               [placeholder]="'John'"
@@ -224,7 +224,7 @@ export const RegistrationForm: Story = {
             [required]="true">
           </app-input>
 
-          <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+          <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr)); gap: 1rem;">
             <app-input
               [label]="'Password'"
               [type]="'password'"

--- a/src/app/examples/settings-example.stories.ts
+++ b/src/app/examples/settings-example.stories.ts
@@ -75,7 +75,7 @@ export const AccountSettings: Story = {
           { label: 'Settings' }
         ]" style="display: block; margin-bottom: 2rem;"></app-breadcrumb>
 
-        <div style="display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 0.5rem;">
+        <div style="display: flex; align-items: flex-start; justify-content: space-between; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.5rem;">
           <app-heading [level]="1">Account settings</app-heading>
           <app-menu label="Account actions" [entries]="[
             { label: 'Export data' },
@@ -100,12 +100,12 @@ export const AccountSettings: Story = {
         <section style="margin-bottom: 2.5rem;">
           <app-heading [level]="2" style="font-size: var(--font-size-lg); margin-bottom: 1.5rem;">Profile</app-heading>
           <div style="display: flex; flex-direction: column; gap: 1rem;">
-            <div style="display: flex; justify-content: space-between; align-items: center; padding: 1rem; background: var(--color-bg-surface); border-radius: var(--radius-md);">
-              <div>
+            <div style="display: flex; justify-content: space-between; align-items: flex-start; gap: 0.5rem; padding: 1rem; background: var(--color-bg-surface); border-radius: var(--radius-md);">
+              <div style="min-width: 0;">
                 <div style="font-family: var(--font-family-accessible); font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--color-text-default); letter-spacing: 0.02em;">Jane Smith</div>
-                <div style="font-family: var(--font-family-accessible); font-size: var(--font-size-sm); color: var(--color-text-subtle); letter-spacing: 0.02em;">j.smith@example.com</div>
+                <div style="font-family: var(--font-family-accessible); font-size: var(--font-size-sm); color: var(--color-text-subtle); letter-spacing: 0.02em; overflow-wrap: break-word;">j.smith@example.com</div>
               </div>
-              <app-badge variant="success">Verified</app-badge>
+              <app-badge variant="success" style="flex-shrink: 0;">Verified</app-badge>
             </div>
           </div>
         </section>
@@ -221,7 +221,7 @@ export const TabbedSettings: Story = {
 
           <app-tab-panel tabId="profile" label="Profile">
             <div style="padding: 1.5rem 0; display: flex; flex-direction: column; gap: 1.25rem;">
-              <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+              <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr)); gap: 1rem;">
                 <app-input label="First name" [value]="'Jane'" [required]="true"></app-input>
                 <app-input label="Last name" [value]="'Smith'" [required]="true"></app-input>
               </div>


### PR DESCRIPTION
## Summary

- All six broken Example stories now render correctly at 320×568 (Storybook `mobile1` viewport) — layout-only changes, no component API changes
- `Alert` component gains `overflow-wrap: break-word` on message text to prevent long tokens (emails, URLs) from overflowing
- `TabsComponent` gains horizontal scroll with a gradient edge-fade affordance (6rem, `0.15s ease`) driven by scroll state signals; new story demos the behavior
- New follow-on issues filed for CLAUDE.md authoring guidance gaps surfaced during QA

Closes #100

## Changes by area

**Example stories** (`src/app/examples/`)
- Chat: `position: fixed; inset: 0` shell, sidebar/nav hidden at ≤600px, input pinned to bottom, `layout: fullscreen`
- Forms / Settings: `1fr 1fr` grids → `repeat(auto-fit, minmax(min(100%, 240px), 1fr))`
- Settings AccountSettings: `flex-wrap: wrap` on header row prevents button overlap
- Settings profile card: `min-width: 0` + `overflow-wrap: break-word` + `flex-shrink: 0` on badge
- Data table: `clamp()` padding, `overflow-x: auto` table wrapper, flexible search input
- Cards: outer padding wrapper, `min(100%, 300px)` CardGrid column floor
- Color iterator: `1fr 1fr` → `auto-fit`

**Components**
- `alert.component.scss`: `overflow-wrap: break-word` on `&__message` (closes #101)
- `tabs.component.ts`: scroll state signals, `afterNextRender` listener + `ResizeObserver`, host class bindings, `OnDestroy` cleanup
- `tabs.component.scss`: `tabs__list-wrapper` with `::before`/`::after` gradient fades; vertical suppression; inverse color override
- `tabs.component.stories.ts`: new "Pattern: Many tabs (scroll affordance)" story

## Follow-on issues

- #102 — responsive two-column grid pattern in CLAUDE.md
- #103 — flex text overflow authoring note in CLAUDE.md
- #104 — mobile viewport check in story workflow

## Test plan

- [ ] Open Storybook, switch viewport to **mobile1 (320×568)**
- [ ] Examples/Chat — sidebar hidden, nav hidden, input pinned to bottom, single scrollbar
- [ ] Examples/Registration Form — name and password rows stack to single column
- [ ] Examples/Tabbed Settings — name row stacks; Security tab scrolls into view with fade signifier
- [ ] Examples/Filterable Table — table scrolls horizontally, search input shrinks gracefully
- [ ] Examples/Cards — 1rem padding from edge, no overflow at 320px
- [ ] Examples/Color Iterator — columns stack vertically
- [ ] Components/Tabs → "Pattern: Many tabs" — right fade visible on load, left fade on scroll, fades clear at end
- [ ] Components/Tabs → Inverse — fade uses dark background color
- [ ] Components/Tabs → Vertical orientation — no horizontal fades

🤖 Generated with [Claude Code](https://claude.com/claude-code)