### PR TITLE
feat(pagination,toolbar): compact pagination mode + toolbar horizontal scroll (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`candor-pagination` `compact` attribute** — opt-in compact layout (`‹ Prev · Page X of Y · Next ›`) that drops the numbered page buttons and ellipses for narrow viewports. Set it from a media/container query in a responsive app; defaults to `false` (the full numbered layout is unchanged). The "Page X of Y" position text is a polite live region, so screen readers announce the new page after Prev/Next. Prev/Next keep their existing disabled logic and `page-change` events (#152).
 - **`--color-slider-thumb`** token — the slider handle fill, themed per mode (white in light, light grey `oklch(0.91)` in dark) so the thumb reads as a light puck in both themes. Non-text token (paired with `--color-border-control` for the edge).
 
 ### Changed
@@ -18,6 +19,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **`candor-alert`:** the `message` attribute now renders even when the element has whitespace between its tags (`<candor-alert message="…">\n</candor-alert>`). Previously `message` was the fallback content of an internal `<slot>`, which a whitespace-only child text node suppressed — rendering a blank alert body. `message`, when set, now renders directly; the slot is used only for projected content. (Surfaced by the #143 migration: Angular stripped insignificant whitespace text nodes, lit-html preserves them.)
 - **`candor-menu`:** the checked-item checkmark is no longer rendered upside-down (it read as an upward caret). The `phCheckBold` icon path was vertically flipped; corrected so the tick points down-right.
+- **`candor-toolbar`:** a full horizontal toolbar now scrolls within its own bounds on narrow viewports (`max-width: 100%; overflow-x: auto`) instead of overflowing the page. Items keep their natural size (`flex-shrink: 0`) so the row scrolls rather than squashing; roving-tabindex navigation already scrolls focus into view (#152).
 - **`candor-data-grid` / `candor-tone-picker`:** the grid now scrolls horizontally within its own bounds on narrow viewports instead of overflowing the page.
 - **`candor-toast`:** no longer overflows narrow viewports — `box-sizing: border-box` plus `min(…, 100%)` width caps keep the toast within its container so its text wraps.
 - **`candor-slider`:** the thumb is now visible in dark theme. It previously filled with `--color-bg-page` and used a hard-coded black border/shadow, so in dark mode the handle became the page colour and disappeared. It now uses the themed `--color-slider-thumb` fill with a `--color-border-control` edge.

--- a/audit/pairings.json
+++ b/audit/pairings.json
@@ -715,6 +715,15 @@
       "note": "ellipsis — Tier 3 Supplementary"
     },
     {
+      "id": "pagination-compact-status",
+      "fg": "{color.text.default}",
+      "bg": "{color.bg.page}",
+      "size": 14,
+      "weight": "regular",
+      "min": 9.5,
+      "note": "compact-mode 'Page X of Y' — sole position indicator, so Tier 1 Reading floor; text-default clears it (OKCA 11 light / 12.5 dark)"
+    },
+    {
       "id": "chip-default",
       "fg": "{color.text.default}",
       "bg": "{color.bg.surface}",

--- a/src/web-components/components/pagination/candor-pagination.stories.ts
+++ b/src/web-components/components/pagination/candor-pagination.stories.ts
@@ -37,9 +37,13 @@ to give screen readers a unique landmark name (e.g. \`"Documents pagination"\`,
       control: { type: 'number', min: 1 },
       description: 'Total number of pages',
     },
+    compact: {
+      control: 'boolean',
+      description: 'Compact layout: ‹ Prev · Page X of Y · Next › — drops the numbered buttons. Opt-in for narrow viewports.',
+    },
   },
-  args: { currentPage: 3, totalPages: 10 },
-  render: (args) => html`<candor-pagination current-page="${args['currentPage']}" total-pages="${args['totalPages']}"></candor-pagination>`,
+  args: { currentPage: 3, totalPages: 10, compact: false },
+  render: (args) => html`<candor-pagination current-page="${args['currentPage']}" total-pages="${args['totalPages']}" ?compact="${args['compact']}"></candor-pagination>`,
 };
 
 export default meta;
@@ -67,6 +71,21 @@ export const ManyPages: Story = {
 
 export const SinglePage: Story = {
   args: { currentPage: 1, totalPages: 1 },
+};
+
+export const Compact: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Compact layout for narrow viewports — Prev/Next flank a plain-text "Page X of Y" position ' +
+          'indicator instead of numbered buttons. Set `compact` from a media/container query in a ' +
+          'responsive app. The position text is a polite live region, so screen readers announce the ' +
+          'new page after Prev/Next (focus stays on the button).',
+      },
+    },
+  },
+  args: { currentPage: 3, totalPages: 10, compact: true },
 };
 
 const tableHeaders = JSON.stringify(['Name', 'Role', 'Status']);

--- a/src/web-components/components/pagination/candor-pagination.ts
+++ b/src/web-components/components/pagination/candor-pagination.ts
@@ -67,10 +67,25 @@ export class CandorPagination extends LitElement {
       letter-spacing: var(--letter-spacing-italic);
       user-select: none;
     }
+    .pagination__status {
+      display: inline-flex;
+      align-items: center;
+      height: var(--spacing-lg);
+      padding: 0 var(--spacing-xs);
+      color: var(--color-text-default);
+      font-family: var(--font-family-accessible);
+      font-size: var(--font-size-sm);
+      letter-spacing: var(--letter-spacing-italic);
+      line-height: 1;
+      white-space: nowrap;
+    }
   `;
 
   @property({ type: Number, attribute: 'current-page' }) currentPage = 1;
   @property({ type: Number, attribute: 'total-pages' }) totalPages = 1;
+  // Compact mode: ‹ Prev · Page X of Y · Next › — drops the numbered buttons
+  // and ellipses. Opt-in (e.g. a responsive app sets it from a media query).
+  @property({ type: Boolean, reflect: true }) compact = false;
 
   // aria-label observed manually so the attribute is stripped off the host
   // (avoids host/inner double-naming — see utils/host-aria.ts).
@@ -109,13 +124,38 @@ export class CandorPagination extends LitElement {
     this.requestUpdate();
   }
 
+  private _renderPrev() {
+    return html`
+      <button class="pagination__btn pagination__prev" ?disabled="${this.currentPage <= 1}" aria-label="Previous page" @click="${() => this._goTo(this.currentPage - 1)}">
+        <svg class="pagination__icon pagination__icon--prev" aria-hidden="true" viewBox="0 0 1024 1024" fill="currentColor"><path d="${phCaretDownBold}"/></svg>
+      </button>
+    `;
+  }
+
+  private _renderNext() {
+    return html`
+      <button class="pagination__btn pagination__next" ?disabled="${this.currentPage >= this.totalPages}" aria-label="Next page" @click="${() => this._goTo(this.currentPage + 1)}">
+        <svg class="pagination__icon pagination__icon--next" aria-hidden="true" viewBox="0 0 1024 1024" fill="currentColor"><path d="${phCaretDownBold}"/></svg>
+      </button>
+    `;
+  }
+
   override render() {
+    if (this.compact) {
+      // Page position is the sole on-screen indicator here, so announce it
+      // politely when Prev/Next changes the page (focus stays on the button).
+      return html`
+        <nav aria-label="${this._ariaLabel}" class="pagination pagination--compact">
+          ${this._renderPrev()}
+          <span class="pagination__status" aria-live="polite" aria-atomic="true">Page ${this.currentPage} of ${this.totalPages}</span>
+          ${this._renderNext()}
+        </nav>
+      `;
+    }
     return html`
       <nav aria-label="${this._ariaLabel}" class="pagination">
-        <button class="pagination__btn pagination__prev" ?disabled="${this.currentPage <= 1}" aria-label="Previous page" @click="${() => this._goTo(this.currentPage - 1)}">
-          <svg class="pagination__icon pagination__icon--prev" aria-hidden="true" viewBox="0 0 1024 1024" fill="currentColor"><path d="${phCaretDownBold}"/></svg>
-        </button>
-        ${this._pages.map((item, i) =>
+        ${this._renderPrev()}
+        ${this._pages.map((item) =>
           item === 'ellipsis'
             ? html`<span class="pagination__ellipsis" aria-hidden="true">…</span>`
             : html`<button
@@ -125,9 +165,7 @@ export class CandorPagination extends LitElement {
                 @click="${() => this._goTo(item as number)}"
               >${item}</button>`
         )}
-        <button class="pagination__btn pagination__next" ?disabled="${this.currentPage >= this.totalPages}" aria-label="Next page" @click="${() => this._goTo(this.currentPage + 1)}">
-          <svg class="pagination__icon pagination__icon--next" aria-hidden="true" viewBox="0 0 1024 1024" fill="currentColor"><path d="${phCaretDownBold}"/></svg>
-        </button>
+        ${this._renderNext()}
       </nav>
     `;
   }

--- a/src/web-components/components/toolbar/candor-toolbar.ts
+++ b/src/web-components/components/toolbar/candor-toolbar.ts
@@ -28,12 +28,22 @@ export class CandorToolbar extends LitElement {
       background: var(--color-bg-surface);
       border: var(--border-width-thin) solid var(--color-border-default);
       border-radius: var(--radius-md);
+      /* On narrow viewports a full toolbar scrolls in a single row instead of
+         overflowing the page. Roving-tabindex nav already scrolls focus into
+         view, so keyboard users follow the row as they arrow through it. */
+      max-width: 100%;
+      overflow-x: auto;
     }
+    /* Keep each item at its natural size so the row scrolls rather than the
+       items squashing (flex children shrink by default). */
+    ::slotted(*) { flex-shrink: 0; }
     .toolbar--vertical {
       display: flex;
       flex-direction: column;
       align-items: stretch;
       width: fit-content;
+      max-width: 100%;
+      overflow-x: visible;
     }
   `;
 


### PR DESCRIPTION
Closes #152.

Two narrow-viewport fixes surfaced during the #143 migration mobile sweep, per the issue's decided approach.

## `candor-pagination` — compact mode (new `compact` attribute)
- New `@property({ type: Boolean, reflect: true }) compact = false`. When set, renders `‹ Prev · Page X of Y · Next ›` and drops the numbered buttons + ellipses. Default `false` preserves today's full numbered layout — consumer opts in (e.g. from a media/container query). No automatic container-query switch in this pass, explicit prop only.
- Prev/Next reuse the existing disabled logic and `page-change` events (extracted into shared `_renderPrev`/`_renderNext` used by both layouts).
- The "Page X of Y" position text is the sole on-screen indicator in this mode, so it's a **polite, atomic live region** — screen readers announce the new page after Prev/Next (focus stays on the button). It uses `--color-text-default` (OKCA **11** light / **12.5** dark — clears the Tier 1 Reading floor of 9.5). Nav `aria-label` is unchanged.
- Added `Compact` story + `compact` control, and a `pagination-compact-status` entry to `audit/pairings.json`.

## `candor-toolbar` — horizontal scroll
- `.toolbar { max-width: 100%; overflow-x: auto; }` so a full toolbar scrolls in a single row instead of overflowing the page. `::slotted(*) { flex-shrink: 0 }` keeps items at their natural size (flex children shrink by default, which would squash them before scrolling). Vertical orientation keeps `overflow-x: visible`. No API change.

## Verification (Playwright probe at 305px)
- `toolbar--with-separators` & `toolbar--data-table-actions`: document overflow **0**, toolbar `scrollWidth > clientWidth` (scrolls within bounds). ✅
- `overflow-x: auto` forces `overflow-y: auto`, but the focus ring (2px + 2px offset = 4px) fits the item's 5px gap inside the toolbar padding — **not clipped** (measured + screenshotted). ✅
- `pagination--compact`: 0 numbered buttons, status text `"Page 3 of 10"` with `aria-live="polite"`, prev/next present, nav label preserved. Reads cleanly in light + dark. ✅
- `npm run build:wc` clean; `audit/pairings.json` valid.

## Out of scope (per issue)
`account-settings` (389px) is a separate root-cause follow-up — its overflow root (likely `candor-tabs` or a control row) is handled separately, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
