### PR TITLE
docs(theme-b1): token-doc corrections (#109, #115, #108)

### DIFF
--- a/docs/DESIGN-TOKENS.md
+++ b/docs/DESIGN-TOKENS.md
@@ -1,533 +1,146 @@
 # Design Tokens Guide
 
-## Overview
+Candor's design tokens are the single source of truth for color, typography, spacing, and shape. This guide explains **how the token system is structured** and **how to work with it**. It deliberately does not re-list every token value — those live in the source files and the Storybook "Design Tokens" stories, which are the authoritative reference. A prose doc that duplicates values drifts out of date; this one points at the files instead.
 
-Design tokens are the single source of truth for all design decisions in this playground. They centralize colors, typography, spacing, and other design values, making it easy to iterate on art direction.
-
-## Why Design Tokens?
-
-**The Problem:**
-Without tokens, design values are scattered across components:
-```scss
-// ❌ Hard-coded values everywhere
-.button { 
-  background: #3B82F6; 
-  font-size: 16px; 
-  padding: 12px 24px;
-}
-.card { 
-  background: #3B82F6; 
-  font-size: 16px; 
-}
-```
-
-When art direction changes, you have to hunt down every instance.
-
-**The Solution:**
-With tokens, update once, cascade everywhere:
-```scss
-// ✅ Design tokens
-$color-primary: oklch(0.55 0.18 250);
-$font-size-md: 1rem;
-$spacing-md: 1.5rem;
-
-// Components use tokens
-.button { 
-  background: $color-primary; 
-  font-size: $font-size-md; 
-  padding: $spacing-md;
-}
-```
+> **Source of truth:** `src/design-tokens/primitives.scss` and `src/design-tokens/semantics.scss`. Both are heavily commented with the contrast rationale behind each value. When this guide and the SCSS disagree, the SCSS is correct — open an issue.
 
 ---
 
-## Token Files
+## Format: CSS custom properties, not SCSS variables
 
-All design tokens live in `src/design-tokens/`:
+Tokens are **CSS custom properties** (`--color-action-primary`), not SCSS variables (`$color-primary`). SCSS is used only as a light authoring convenience — to wrap the light/dark token sets in mixins (`light-color-tokens` / `dark-color-tokens`) and emit them under the right selectors. Every token is a runtime `var(--…)` reference.
+
+This matters because custom properties:
+
+- **Pierce the Shadow DOM.** Candor ships as Lit web components with shadow roots. Custom properties inherit through shadow boundaries; SCSS variables (resolved at build time) cannot. Loading the token stylesheet once on the page reaches every component's internals.
+- **Switch themes at runtime.** Light/dark is a matter of which `--color-*` values are in scope, toggled by `[data-theme]` or `prefers-color-scheme` — no rebuild.
+
+```css
+/* ✅ How components and consumers reference tokens */
+.button {
+  background: var(--color-action-primary);
+  padding: var(--spacing-button-padding-y) var(--spacing-button-padding-x);
+  border-radius: var(--radius-md);
+}
+```
+
+Never hard-code an `oklch(…)` value or a raw px inside a component — reference the token.
+
+---
+
+## Two layers: primitives → semantics
+
+Tokens are split into two files with a strict one-way dependency.
 
 ```
 src/design-tokens/
-├── colors.scss       ← Color palette
-├── typography.scss   ← Font families, sizes, weights
-├── spacing.scss      ← Spacing scale
-└── index.scss        ← Exports all tokens
+├── primitives.scss   ← raw values: color ramps, scales. No meaning, no context.
+├── semantics.scss    ← named roles that map primitives to usage. Components use THESE.
+├── article.scss      ← long-form prose styles (candor-article)
+├── syntax.scss       ← code syntax-highlighting tokens
+├── blog.scss         ← blog example styles
+└── index.scss        ← aggregates and exports everything
 ```
 
-### Importing Tokens
+### Primitives (`primitives.scss`)
 
-Tokens are automatically imported globally via `src/styles.scss`:
+Raw, context-free values under `:root`. Color **ramps** (each family is a perceptually-spaced 50–900 scale at constant hue/chroma), the spacing scale (`--space-1` … `--space-12`, 8px base), the type scale (`--text-xs` … `--text-3xl`, Major Third 1.25 ratio), font stacks, weights, line heights, tracking, and border/radius primitives.
 
-```scss
-// src/styles.scss
-@use './design-tokens' as *;
-```
+Color families: **navy** (primary brand anchor, `navy-800` = `#082840`), **burgundy** (secondary), **azure** (links/accent), **indigo** (visited links, decorative accent), and a neutral **gray** ramp. Each ramp step is annotated with its contrast behaviour — e.g. `azure-400` is the original brand blue but only 3.2:1 on white, so `azure-500`/`600` are the accessible steps.
 
-This means **all SCSS files can use token variables** without importing them.
+> **Components must never reference a primitive directly.** `var(--navy-800)` in a component is a bug — it bypasses the semantic layer and breaks dark mode. Always go through a `--color-*` role.
+
+### Semantics (`semantics.scss`)
+
+Named **roles** that map primitives (or direct OKLCH values, where a role needs a value the ramp doesn't carry) to meaning. This is the layer components and consumers reference:
+
+- **Backgrounds** — `--color-bg-page`, `--color-bg-surface`, `--color-bg-subtle`, `--color-bg-elevated`, `--color-bg-inverse`
+- **Text** — `--color-text-default`, `--color-text-subtle`, `--color-text-subtle-on-surface`, `--color-text-inverse`, `--color-text-on-action`, …
+- **Borders** — `--color-border-default`, `--color-border-strong`, `--color-border-control`, …
+- **Actions** — `--color-action-primary` (navy), `-secondary` (burgundy), `-tertiary`, `-destructive`, each with `-hover`/`-active` and, where relevant, `-text`/`-border`
+- **Link / highlight / status / blockquote / callout / code** — role-specific color sets
+- **Spacing** — `--spacing-2xs` … `--spacing-3xl` plus component-scoped tokens (`--spacing-button-padding-*`, `--spacing-input-padding-*`, `--spacing-card-*`)
+- **Typography** — `--font-family-*` (with role comments), `--font-size-*`, `--font-weight-*`, `--line-height-*`, `--letter-spacing-*`
+- **Shape / interaction** — `--radius-*`, `--border-width-*`, `--focus-ring-*`, `--hit-target-aaa`/`-aa`
+- **Elevation** — `--shadow-sm` … `--shadow-modal`
+
+Many semantic tokens carry an inline OKCA contrast note (e.g. `// OKCA 11 on page ✅`). Those notes are load-bearing — they record *why* a value is what it is. Preserve them when editing.
 
 ---
 
-## Colors (colors.scss)
+## Color: OKLCH
 
-### Format: OKLCH
+All colors are authored in **OKLCH** — `oklch(L C H)`:
 
-We use **OKLCH** format instead of hex/RGB because:
+- **L** — lightness, 0 (black) → 1 (white)
+- **C** — chroma, 0 (gray) → ~0.4 (vivid)
+- **H** — hue, 0–360°
 
-1. **Perceptually uniform**: Equal changes create equal visual changes
-2. **Predictable**: L=0.5 looks "mid-tone" across all hues
-3. **klar CLI compatible**: Easy to manipulate programmatically with `klar` commands
-4. **Better variants**: Generate tints/shades that look natural
-
-### OKLCH Syntax
-
-```scss
-oklch(L C H)
-
-// L = Lightness (0 to 1)
-//     0 = black, 0.5 = mid-tone, 1 = white
-//
-// C = Chroma (0 to ~0.4)
-//     0 = grayscale, 0.1 = muted, 0.3+ = vibrant
-//
-// H = Hue (0 to 360)
-//     0/360 = red, 120 = green, 240 = blue, etc.
-```
-
-### Example Colors
-
-```scss
-// Primary Colors
-$color-primary: oklch(0.55 0.18 250); // Blue
-$color-primary-hover: oklch(0.45 0.18 250); // Darker blue (lower L)
-$color-primary-active: oklch(0.35 0.18 250); // Even darker
-
-// Neutral Colors
-$color-background: oklch(0.98 0.01 250); // Almost white
-$color-surface: oklch(0.95 0.01 250); // Light gray
-$color-border: oklch(0.85 0.01 250); // Medium gray
-
-// Text Colors
-$color-text-primary: oklch(0.25 0.01 250); // Near black
-$color-text-secondary: oklch(0.50 0.01 250); // Medium gray
-$color-text-disabled: oklch(0.65 0.01 250); // Light gray
-
-// Semantic Colors
-$color-error: oklch(0.55 0.22 25); // Red
-$color-success: oklch(0.55 0.15 145); // Green
-$color-warning: oklch(0.65 0.18 85); // Orange
-```
-
-### Converting Hex to OKLCH
-
-Use the klar CLI:
-
-```bash
-klar meta "#3B82F6"
-# → Lightness: 0.55, Chroma: 0.18, Hue: 250.8°
-# Use these values: oklch(0.55 0.18 250.8)
-```
-
-### Browser Compatibility
-
-Modern browsers support OKLCH directly. For older browsers, add a fallback:
-
-```scss
-.button {
-  background: #3B82F6; // Fallback for old browsers
-  background: oklch(0.55 0.18 250); // Modern browsers
-}
-```
+OKLCH is perceptually uniform (equal L steps look equally different across hues), which is what lets the ramps be evenly spaced and lets the klar CLI adjust a color's lightness for contrast without shifting its hue. Convert an art-direction hex with `klar meta "#…"`.
 
 ---
 
-## Typography (typography.scss)
+## Fonts
 
-### Font Families
+Candor uses five typefaces, each with a defined role (see the primitive `--font-*` stacks and the semantic `--font-family-*` roles):
 
-```scss
-$font-family-base: system-ui, -apple-system, BlinkMacSystemFont, 
-                   'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-$font-family-mono: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', 
-                   Consolas, 'Courier New', monospace;
-```
+| Role token | Typeface | Use |
+|---|---|---|
+| `--font-family-base` / `-display` | Roboto Flex (variable) | UI workhorse; headings via the weight/`opsz` axes |
+| `--font-family-accessible` | Atkinson Hyperlegible | Instructional UI text the user must read precisely |
+| `--font-family-reading` | Noto Sans | Conversational / long-form UI prose |
+| `--font-family-serif` | Noto Serif | Authored & AI-generated articles (candor-article) |
+| `--font-family-mono` | Roboto Mono | Code, and cells where character position is load-bearing |
 
-**System fonts** load instantly (no web font delay) and look native to each platform.
-
-**To use a custom font:**
-```scss
-$font-family-base: 'Inter', system-ui, sans-serif;
-```
-
-Then add the font to `src/index.html` or import from Google Fonts.
-
-### Type Scale
-
-Based on **Major Third (1.25 ratio)**:
-
-```scss
-$font-scale: 1.25;
-
-// Sizes
-$font-size-xs: 0.64rem;   // ~10px
-$font-size-sm: 0.8rem;    // ~13px
-$font-size-md: 1rem;      // 16px (base)
-$font-size-lg: 1.25rem;   // ~20px
-$font-size-xl: 1.563rem;  // ~25px
-$font-size-2xl: 1.953rem; // ~31px
-$font-size-3xl: 2.441rem; // ~39px
-
-// Heading sizes
-$font-size-h1: $font-size-3xl; // ~39px
-$font-size-h2: $font-size-2xl; // ~31px
-$font-size-h3: $font-size-xl;  // ~25px
-$font-size-h4: $font-size-lg;  // ~20px
-$font-size-h5: $font-size-md;  // 16px
-$font-size-h6: $font-size-sm;  // ~13px
-```
-
-**Why Major Third?**
-- Creates noticeable size differences
-- Not too extreme (like Perfect Fourth 1.33)
-- Not too subtle (like Minor Second 1.125)
-- Works well for UI and content
-
-**Common type scales:**
-- Minor Second: 1.125 (subtle)
-- Major Second: 1.125 (subtle)
-- Minor Third: 1.2 (moderate)
-- **Major Third: 1.25** ← We use this
-- Perfect Fourth: 1.333 (dramatic)
-- Golden Ratio: 1.618 (very dramatic)
-
-### Font Weights
-
-```scss
-$font-weight-regular: 400;
-$font-weight-medium: 500;
-$font-weight-semibold: 600;
-$font-weight-bold: 700;
-```
-
-### Line Heights
-
-```scss
-$line-height-tight: 1.25;  // Headlines
-$line-height-normal: 1.5;  // Body text (default)
-$line-height-loose: 1.75;  // Long-form content
-```
-
-### Letter Spacing
-
-```scss
-$letter-spacing-tight:   -0.025em; // Large headings
-$letter-spacing-normal:  0;        // Default
-$letter-spacing-relaxed: 0.03em;   // Small body text, captions — between normal and wide
-$letter-spacing-wide:    0.05em;   // All caps, labels
-```
+The typeface roles are not interchangeable — see the "Typography Usage Rules" in `CLAUDE.md` for the instruction-vs-comprehension decision and the Roboto Flex variable-axis guidance. Fonts are delivered via Fontsource packages (deps of the tokens package); see #169 for the optional `candor-fonts.css` convenience import.
 
 ---
 
-## Spacing (spacing.scss)
+## Consuming the tokens
 
-### 8px Grid System
+Consumers install `@candor-design/tokens` and load the built stylesheet once:
 
-Based on **8px baseline**:
-
-```scss
-$spacing-unit: 0.5rem; // 8px
-
-$spacing-xs: 0.5rem;   // 8px
-$spacing-sm: 1rem;     // 16px
-$spacing-md: 1.5rem;   // 24px
-$spacing-lg: 2rem;     // 32px
-$spacing-xl: 3rem;     // 48px
-$spacing-2xl: 4rem;    // 64px
-$spacing-3xl: 6rem;    // 96px
+```css
+@import "@candor-design/tokens/candor-tokens.css";
 ```
 
-**Why 8px?**
-- Most screen sizes divide evenly by 8
-- Aligns with common component sizes (16, 24, 32, etc.)
-- Easy mental math (2× = 16px, 3× = 24px)
-- Industry standard (iOS, Material Design)
+That single import puts every `--color-*`, `--spacing-*`, `--font-*`, `--radius-*` (etc.) in scope for the whole page, including inside any web component's shadow root. The built artifacts live in `tokens/` (`candor-tokens.css`, `candor-tokens.min.css`, and the DTCG `candor-tokens.json`) and are produced by `npm run build:tokens`.
 
-### Usage Examples
+### Light and dark
 
-```scss
-// Component spacing
-.card {
-  padding: $spacing-md; // 24px
-  margin-bottom: $spacing-lg; // 32px
-}
+Color tokens ship in both modes. Dark is applied two ways, kept in sync because both include the same `dark-color-tokens` mixin:
 
-// Button padding
-.button {
-  padding: $spacing-sm $spacing-md; // 16px 24px (vertical horizontal)
-}
+- `@media (prefers-color-scheme: dark)` — follows the OS/browser preference automatically.
+- `[data-theme="dark"]` on `<html>` — manual override via JS.
 
-// Section spacing
-.section {
-  margin-top: $spacing-2xl; // 64px
-  padding: $spacing-xl 0; // 48px 0
-}
-```
-
-### Spacing Scale Visualization
-
-The **Spacing Showcase** story (`src/web-components/design-tokens/spacing-showcase.stories.ts`) visually displays the spacing scale in Storybook.
+Spacing, typography, and shape tokens are **mode-invariant** — they are defined once and not repeated per theme. Only color changes between modes.
 
 ---
 
-## How to Update Tokens
+## Maintainer workflow: changing a token
 
-### Scenario 1: New Art Direction Colors
+1. **Edit the right layer.** Adjusting a role (e.g. making the primary button darker on hover) → `semantics.scss`. Adding or reshaping a raw ramp → `primitives.scss`. Never hard-code a value in a component.
+2. **Keep it OKLCH.** Convert any incoming hex with `klar meta`.
+3. **Re-export the DTCG artifact.** Run `npm run audit:tokens` after any change to `primitives.scss`/`semantics.scss` — it regenerates `audit/tokens.dtcg.json` (the canonical input for contrast audits).
+4. **Validate contrast.** For each changed color token, grep `audit/pairings.json` for its DTCG name to find every pairing that references it, then check each with `klar contrast <fg> <bg> -q` against the pairing's `min` floor. See the "OKCA Contrast Thresholds" section in `CLAUDE.md` for the two-axis (size × use-case tier) threshold table.
+5. **Preview in Storybook.** The "Design Tokens" stories render the ramps, semantic swatches, spacing, and type scale live — the best visual check. Every component picks up the change automatically because they all consume the same custom properties.
 
-**Art direction:** Primary color `#FF5733`, background `#FFFFFF`
-
-1. **Convert to OKLCH** (ask Claude):
-   ```
-   User: "Convert #FF5733 to OKLCH"
-   Claude: oklch(0.63 0.22 28)
-   ```
-
-2. **Update `colors.scss`:**
-   ```scss
-   $color-primary: oklch(0.63 0.22 28);
-   $color-background: oklch(0.98 0.01 0);
-   ```
-
-3. **Validate with klar CLI** (Claude does this):
-   ```bash
-   klar contrast "#FF5733" "#FFFFFF" -q   # → check ratio ≥ 4.5
-   ```
-
-4. **View in Storybook:**
-   ```bash
-   npm run storybook
-   ```
-   All components automatically use new colors.
-
-### Scenario 2: Change Typography
-
-**Art direction:** Use Inter font, larger base size
-
-1. **Update `typography.scss`:**
-   ```scss
-   $font-family-base: 'Inter', system-ui, sans-serif;
-   $font-size-base: 1.125rem; // 18px instead of 16px
-   ```
-
-2. **Add font to `src/index.html`:**
-   ```html
-   <link rel="preconnect" href="https://fonts.googleapis.com">
-   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-   ```
-
-3. **All components automatically update** because they use `$font-family-base` and the type scale.
-
-### Scenario 3: Tighter Spacing
-
-**Art direction:** Reduce spacing for compact UI
-
-1. **Update `spacing.scss`:**
-   ```scss
-   $spacing-unit: 0.375rem; // 6px instead of 8px
-   
-   // Scale automatically updates:
-   $spacing-xs: 0.375rem;  // 6px
-   $spacing-sm: 0.75rem;   // 12px
-   $spacing-md: 1.125rem;  // 18px
-   // ... etc
-   ```
-
-2. **Components automatically use new spacing.**
+New semantic tokens should earn their place: a token with no previewable consumer in Storybook is hard to justify.
 
 ---
 
-## Best Practices
+## Governance & naming
 
-### 1. Never Hard-Code Values
-
-```scss
-// ❌ Bad
-.button { 
-  background: #3B82F6; 
-  padding: 16px;
-}
-
-// ✅ Good
-.button { 
-  background: $color-primary; 
-  padding: $spacing-sm;
-}
-```
-
-### 2. Use Semantic Token Names
-
-```scss
-// ❌ Bad (too specific)
-$blue-500: oklch(0.55 0.18 250);
-$blue-600: oklch(0.45 0.18 250);
-
-// ✅ Good (semantic meaning)
-$color-primary: oklch(0.55 0.18 250);
-$color-primary-hover: oklch(0.45 0.18 250);
-```
-
-Semantic names make it clear **why** the color is used, not just what it looks like.
-
-### 3. Start with Tokens, Not Components
-
-When iterating on design:
-1. **Update tokens first** → `src/design-tokens/colors.scss`
-2. **View impact in Storybook** → See all components update
-3. **Validate with CPQI CLI** → Claude checks accessibility
-4. **Iterate on tokens** → Repeat until satisfied
-
-Don't modify individual components unless the change is component-specific.
-
-### 4. Document Constraints
-
-When you discover limitations, add comments:
-
-```scss
-// Primary color requires minimum 14px text for accessibility (APCA 68)
-$color-primary: oklch(0.63 0.22 28);
-
-// Background cannot go darker than L=0.92 while maintaining contrast
-$color-background: oklch(0.98 0.01 0);
-```
-
-### 5. Test in Context
-
-Tokens look different in components vs. in isolation:
-- View in **Storybook** with real components
-- Use **Playwright** screenshots for visual verification
-- Test on **different backgrounds** (use Storybook backgrounds addon)
+- **Token names are public API.** Adding a token is a minor release; renaming or removing one is a major (breaking) change — see `docs/BREAKING-CHANGES.md`. Rename in `primitives.scss`/`semantics.scss`, re-run `npm run audit:tokens`, and update any `audit/pairings.json` references.
+- **Naming pattern:** `--color-{role}[-{variant}][-{context}]` (e.g. `--color-text-subtle-on-surface`), `--spacing-{scale}`, `--font-{property}-{name}`, `--radius-{size}`. Roles describe *why* a value is used, not what it looks like.
+- **Non-text tokens are flagged.** Tokens annotated `icon/border use` in `semantics.scss` are contrast-validated only for non-text use (icons, borders, indicators) and are exported with `$extensions.usage: "non-text"` in the DTCG file. Never use one as a CSS `color:` value for text — use the paired `-text` variant. See pitfall #3a in `CLAUDE.md`.
 
 ---
 
-## Token Naming Conventions
+## Reference
 
-### Colors
-
-```scss
-// Pattern: $color-{purpose}-{variant}
-
-$color-primary              // Main brand color
-$color-primary-hover        // Hover state
-$color-primary-active       // Active/pressed state
-
-$color-text-primary         // Main text
-$color-text-secondary       // Secondary text
-$color-text-disabled        // Disabled text
-
-$color-background           // Page background
-$color-surface              // Card/panel background
-$color-border               // Borders
-
-$color-error                // Error state
-$color-error-bg             // Error background
-$color-success              // Success state
-$color-warning              // Warning state
-```
-
-### Typography
-
-```scss
-// Font families
-$font-family-{purpose}      // base, mono, display
-
-// Font sizes
-$font-size-{scale}          // xs, sm, md, lg, xl, 2xl, 3xl
-$font-size-{element}        // h1, h2, h3, h4, h5, h6, body, caption
-
-// Font weights
-$font-weight-{name}         // regular, medium, semibold, bold
-
-// Line heights
-$line-height-{density}      // tight, normal, loose
-
-// Letter spacing
-$letter-spacing-{density}   // tight, normal, wide
-```
-
-### Spacing
-
-```scss
-// Pattern: $spacing-{scale}
-
-$spacing-xs     // Extra small
-$spacing-sm     // Small
-$spacing-md     // Medium (default)
-$spacing-lg     // Large
-$spacing-xl     // Extra large
-$spacing-2xl    // 2× extra large
-$spacing-3xl    // 3× extra large
-```
-
----
-
-## Exporting Tokens
-
-### For Other Platforms
-
-You may want to export tokens to Figma, iOS, Android, etc.
-
-**Future enhancement:**
-```bash
-npm run export-tokens
-```
-
-Would generate:
-- `tokens.json` (generic format)
-- `tokens.figma.json` (Figma plugin format)
-- `Colors.swift` (iOS)
-- `colors.xml` (Android)
-
----
-
-## Troubleshooting
-
-### "Changes not showing in Storybook"
-
-1. **Restart Storybook:**
-   ```bash
-   # Stop Storybook (Ctrl+C)
-   npm run storybook
-   ```
-
-2. **Clear cache:**
-   ```bash
-   rm -rf .storybook-cache node_modules/.cache
-   npm run storybook
-   ```
-
-### "Colors look different than expected"
-
-1. **Check browser support:** OKLCH is modern (Chrome 111+, Safari 15.4+)
-2. **Add fallback hex:** Some older browsers need it
-3. **Verify in multiple browsers:** Use Playwright to screenshot
-
-### "Font not loading"
-
-1. **Check import in `src/index.html`:**
-   ```html
-   <link href="https://fonts.googleapis.com/..." rel="stylesheet">
-   ```
-
-2. **Or import in `src/styles.scss`:**
-   ```scss
-   @import url('https://fonts.googleapis.com/...');
-   ```
-
-3. **Check network tab:** Verify font files are loading
-
----
-
-## Resources
-
-- [OKLCH Color Picker](https://oklch.com/)
-- [Type Scale Calculator](https://typescale.com/)
-- [Modular Scale](https://www.modularscale.com/)
-- [8-Point Grid](https://spec.fm/specifics/8-pt-grid)
-- [Design Tokens Community](https://designtokens.org/)
+- **Live token reference:** Storybook → *Design Tokens* (color ramps, semantic swatches, spacing, type scale)
+- **Source of truth:** `src/design-tokens/primitives.scss`, `src/design-tokens/semantics.scss`
+- **Contrast workflow:** `docs/KLAR-INTEGRATION.md`, `CLAUDE.md` → "OKCA Contrast Thresholds"
+- **Typography roles:** `CLAUDE.md` → "Typography Usage Rules"; `docs/LESSONS-LEARNED.md`
+- **External:** [OKLCH Color Picker](https://oklch.com/), [Type Scale Calculator](https://typescale.com/)

--- a/docs/VISUAL-DESIGN.md
+++ b/docs/VISUAL-DESIGN.md
@@ -208,11 +208,28 @@ Images that serve none of these are filler, and filler signals that no one made 
 - **Photography and illustration inherit the humanist frame.** A page of warm serif prose with a harsh, desaturated stock photo is incoherent. If photography is used in an Article or editorial surface, it should sit visually inside the system's palette — either through the image selection itself, or through treatment (warm overlay, border, container sized on the spatial grid).
 - **Data visualization is a specific case.** Charts must use the status and action tokens, not a parallel chart palette. A "chart red" that differs from `--color-status-error` means the system has two reds, and a user has to learn which means what. If charts need more colors than the semantic palette provides, generate them from the same OKLCH foundation (`klar variants`).
 
+### Icon weight semantics
+
+Candor's icon system is **Phosphor Icons** — a humanist family (rounded, even strokes, no sharp corners) that matches the typefaces. Phosphor ships three weights, and the weight is not a stylistic choice: it encodes the icon's *role*. Reaching for the wrong weight is the same class of error as setting a form label in Noto Serif.
+
+| Weight | Base class | When to use | Why |
+|---|---|---|---|
+| **Fill** | `ph-fill` | Action icons — close, dismiss, add, search, download | Solid forms read as "tappable objects" — the fill signals intent to act |
+| **Bold** | `ph-bold` | Directional affordances — carets, chevrons, arrows | A bold outline is enough for a directional cue; fill would over-weight a subtle hint |
+| **Regular** | `ph` | Informational / status — alerts, badges, metadata, decoration | The lighter weight recedes; the adjacent text or color carries the meaning |
+
+**Bold is reserved for directional affordances only** — carets, chevrons, arrows. It is not an emphasis weight. Using `ph-bold` for a dismiss control, an action button, or any icon that isn't pointing somewhere is the most common misuse (a dismiss "✕" is an action → `ph-fill`, not `ph-bold`). Bold's single job is "this points in a direction."
+
+There is no `ph-regular` class — the regular weight's base class is simply `ph`. Never put two weight classes on one element; each weight sets `font-family: !important` and the last-imported one silently wins.
+
+See the Storybook **Design Tokens → Icons** page for the full reference — installation, per-weight live examples, sizing, the shadow-DOM caveat, and the accessible-name patterns for decorative vs. icon-only buttons.
+
 ### Traps
 
 | Trap | What it looks like | Fix |
 |---|---|---|
 | Decorative icons on headings | A trophy icon next to "Results" | Remove it; the heading level is the signal |
+| Wrong icon weight for the role | A dismiss "✕" set in `ph-bold` | Actions are `ph-fill`; `ph-bold` is for directional cues only |
 | Color-only status dots | A red circle with no label, no icon | Add a label or shape; color cannot be the sole channel |
 | Stock imagery disconnected from palette | Cool-tone hero photo on a warm-neutral page | Recolor, overlay, or replace |
 | Chart palette drift | Bar chart uses `#e74c3c` for "error" | Use `--color-status-error` or OKLCH-derived chart tokens |

--- a/src/web-components/components/toolbar/candor-toolbar.stories.ts
+++ b/src/web-components/components/toolbar/candor-toolbar.stories.ts
@@ -30,6 +30,15 @@ responsibility.
 **Separator:** Use \`<candor-toolbar-separator>\` between logical groups. In a horizontal
 toolbar use the default \`orientation="vertical"\`; in a vertical toolbar set
 \`orientation="horizontal"\`.
+
+> **Story authoring note — the \`btn btn-ghost btn-sm\` classes are Storybook-only.**
+> These stories style their toolbar buttons with utility classes that exist in the
+> Storybook harness but are **not** shipped in \`@candor-design/tokens\`. Don't copy them
+> into an app — they'll render as unstyled browser buttons. The toolbar is a generic
+> container: it supplies structure, ARIA, and roving focus for whatever \`<button>\`s you
+> put inside. For plain controls use \`<candor-button variant="ghost" size="small">\`; for
+> **toggle** controls (Bold/Italic with \`aria-pressed\`) supply your own \`<button>\` and
+> style it — \`candor-button\` has no pressed state.
         `.trim(),
       },
     },

--- a/src/web-components/examples/editor-example.stories.ts
+++ b/src/web-components/examples/editor-example.stories.ts
@@ -18,6 +18,11 @@ controls inside it. Toolbar buttons use native \`<button>\` elements, not
 \`<candor-button>\`, because roving tabindex requires direct focus management on the
 element itself.
 
+> **The \`btn btn-ghost btn-sm\` classes on these buttons are Storybook-only** — they
+> exist in the Storybook harness but are not shipped in \`@candor-design/tokens\`. Don't
+> copy them into an app; style your own \`<button>\`s instead. See the Toolbar story for
+> the full note.
+
 Separators (\`<candor-toolbar-separator>\`) divide the toolbar into logical groups (text style
 vs. alignment vs. insert). The Badge on the document title communicates draft/published
 status at a glance without requiring the user to open a settings panel.


### PR DESCRIPTION
Theme B, wave 1 — pure documentation / story-text corrections. No token or component runtime changes, so nothing ships in the package; this is docs + Storybook copy only.

## Scope
- **Closes #109** — `docs/DESIGN-TOKENS.md` rewritten to match the real system. It described a pre-3.0 architecture (SCSS `$vars`, `colors.scss`/`typography.scss`/`spacing.scss`, a blue primary, a system-ui/SF-Mono font stack) that misled anyone — human or AI agent — reading it in good faith. The rewrite teaches the two-layer primitives→semantics architecture, CSS-custom-property format, OKLCH, the five font roles, consumer import, light/dark, the maintainer workflow, and governance — and **defers actual values to the SCSS source + the Storybook Design Tokens stories** so it can't re-rot the same way.
- **Closes #115** — added an "Icon weight semantics" subsection to `VISUAL-DESIGN.md §4`: the three-tier Phosphor table (fill=action / bold=directional / regular=informational), the explicit "bold is directional affordances only" rule, the no-double-weight-class caveat, a cross-ref to the Storybook Icons page, and a matching trap row.
- **Closes #108** — the `btn btn-ghost btn-sm` classes in the Toolbar and Editor Example stories are Storybook-harness-only (not shipped in `@candor-design/tokens`), so copying the story markup yields unstyled buttons. Angular framing is dead, but the copy-trap survived into the WC stories; since the toolbar is intentionally a generic container for raw `<button>`s (toggle controls need `aria-pressed`, which `candor-button` lacks), the resolution is a **clarifying Storybook-only note** in both stories (per maintainer decision), not a refactor.

## Validation
- Docs-only + story-copy-only; no runtime code touched. CI (builds + a11y + chromatic) validates story compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwsLArMppueSMc4cUHuk9b