### PR TITLE
docs(article): correct :visited demonstrability note (closes #137)

### DIFF
--- a/src/web-components/components/typography/article/candor-article.stories.ts
+++ b/src/web-components/components/typography/article/candor-article.stories.ts
@@ -215,7 +215,7 @@ candor-article a:focus-visible &#123;
   outline-offset: var(--focus-ring-offset);
   border-radius: var(--radius-sm);
 &#125;</code></pre>
-    <p>Note: the <code>:visited</code> double-underline cannot be demonstrated in Storybook — browsers do not apply <code>:visited</code> styles from DevTools force-state or in automated test contexts. See <a href="https://github.com/pawn002/candor/issues/137">issue #137</a> for details.</p>
+    <p>Note: the <code>:visited</code> treatment is <strong>best-effort</strong> and may not render even in a real browser. Chrome's partitioned-visited-links privacy model suppresses <code>:visited</code> styling in most contexts — verified against a <em>guaranteed-visited self-link</em> in a standalone top-level page, so this is not a Storybook-iframe or automation limitation. The rule is kept because it costs nothing and is honoured where the browser permits (e.g. Firefox). Because <code>getComputedStyle()</code> reports the unvisited colour by design, the state cannot be asserted in Playwright or forced via DevTools either. See <a href="https://github.com/pawn002/candor/issues/137">issue #137</a> for the investigation.</p>
   </candor-article>`,
 };
 


### PR DESCRIPTION
## What

Corrects the `LinkStyles` story note in `candor-article.stories.ts`. It previously
claimed the `:visited` double-underline *"cannot be demonstrated in Storybook"* and
blamed the iframe / DevTools force-state / automation. A standalone investigation
showed that framing is wrong.

## Why

Built a top-level (non-iframe) repro loading the real Candor tokens, with two panels
differing in **one variable only** — the `a:visited` rule injected via a `<style>`
element (the shipped fix) vs. via `adoptedStyleSheets` (the original bug). Neither
rendered the visited treatment. The decisive control was a **self-link to the current
page** — a URL guaranteed to be in history, covered by Chrome's partitioned-`:visited`
self-link exception. Even in the `<style>` panel it stayed **azure / single underline**.

That isolates the browser as the only remaining variable: not the iframe, not bfcache,
not the Back button, not history registration, not the injection method. Chrome's
**partitioned visited-links** privacy model (default-on, 2025) suppresses `:visited`
here. `getComputedStyle()` also reports the unvisited colour by design, so the state
can't be asserted in Playwright or forced via DevTools.

## Change

- Reframe the note from *"cannot be demonstrated in Storybook"* to **best-effort; may
  not render even in a real browser** due to Chrome's partitioned-`:visited` model.
- The component-side fix (`adoptedStyleSheets → <style>` in `candor-article.ts`) is
  **retained** — strictly more correct, and honoured where the browser permits (e.g.
  Firefox). No functional change here; docs/story-note only.

Closes #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
