### PR TITLE
docs(readme): sync component count to 37; list missing elements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Colors use OKLCH format: `oklch(L C H)` where:
 The component library is the Lit 3 web components in `src/web-components/components/`:
 - Each component has a `candor-{name}.ts` (Lit class) + `candor-{name}.stories.ts`. Styles live inside the class via `static styles = css\`...\``.
 - Stories use the `@storybook/web-components-vite` `Meta` type and render via lit-html — `render: (args) => html\`…\`` returning custom-element markup (no `template:` strings, no `component:` field).
-- Components register themselves on import via `@customElement('candor-{name}')` — pulling `src/web-components/index.ts` is enough to register all 34 tags.
+- Components register themselves on import via `@customElement('candor-{name}')` — pulling `src/web-components/index.ts` is enough to register all 37 tags.
 - Shadow DOM by default. CSS custom properties pierce shadow boundaries, so tokens reach inner styles without per-component injection.
 
 **Component categories**:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install @candor-design/tokens
 npm install @candor-design/web-components @candor-design/tokens
 ```
 
-Includes all 34 Candor components as Lit 3 custom elements. No framework required — works in plain HTML, React, Vue, Svelte, or any other environment that supports web standards. Version is kept in sync with `@candor-design/tokens`.
+Includes all 37 Candor components as Lit 3 custom elements. No framework required — works in plain HTML, React, Vue, Svelte, or any other environment that supports web standards. Version is kept in sync with `@candor-design/tokens`.
 
 ### Fonts
 
@@ -77,7 +77,7 @@ CSS custom properties pierce Shadow DOM boundaries automatically — loading `ca
 
 ```js
 import '@candor-design/web-components';
-// All 34 custom elements are now registered
+// All 37 custom elements are now registered
 ```
 
 Named exports are also available for direct class access (e.g. typed references, programmatic instantiation). Importing any class still triggers the package's side-effectful `customElements.define()` calls, so the corresponding tag is also registered:

--- a/web-components/README.md
+++ b/web-components/README.md
@@ -29,7 +29,7 @@ Load the tokens stylesheet once at the document level and import the components 
 
 ```js
 import '@candor-design/web-components';
-// All 34 custom elements are now registered
+// All 37 custom elements are now registered
 ```
 
 Named exports give you typed access to the element classes — useful for programmatic instantiation or TypeScript references. Importing a class still triggers `customElements.define()`, so the tag is registered as a side effect:
@@ -40,17 +40,17 @@ import { CandorButton, CandorInput } from '@candor-design/web-components';
 
 ## What's included
 
-34 custom elements covering typography, display, navigation, forms, overlays, and data:
+37 custom elements covering typography, display, navigation, forms, overlays, and data:
 
 | Category | Tags |
 |---|---|
-| Typography | `candor-heading`, `candor-text`, `candor-accessible-text`, `candor-article` |
+| Typography | `candor-heading`, `candor-text`, `candor-accessible-text`, `candor-article`, `candor-code` |
 | Display | `candor-badge`, `candor-alert`, `candor-card`, `candor-stat`, `candor-progress` |
 | Navigation | `candor-button`, `candor-chip`, `candor-breadcrumb`, `candor-pagination`, `candor-toolbar` (+ `candor-toolbar-separator`), `candor-navigation` |
-| Form | `candor-input`, `candor-checkbox`, `candor-radio`, `candor-switch`, `candor-select`, `candor-slider`, `candor-listbox`, `candor-combobox`, `candor-chat-input` |
+| Form | `candor-input`, `candor-autocomplete`, `candor-checkbox`, `candor-radio`, `candor-switch`, `candor-select`, `candor-slider`, `candor-listbox`, `candor-combobox`, `candor-chat-input` |
 | Overlays | `candor-tooltip`, `candor-modal`, `candor-drawer`, `candor-toast` (+ `candor-toast-container`) |
 | Compound | `candor-tabs` (+ `candor-tab-panel`), `candor-accordion-item`, `candor-disclosure`, `candor-menu` |
-| Data | `candor-table`, `candor-data-grid` |
+| Data | `candor-table`, `candor-data-grid`, `candor-tone-picker` |
 
 ## Form participation
 


### PR DESCRIPTION
Follow-up from the post-4.1.0 review (deferred in #195). The component count had drifted to a stale **34** in the package READMEs and one CLAUDE.md note; the real surface is **37 primary elements** (40 registered tags including the 3 parenthetical sub-elements — `candor-toolbar-separator`, `candor-toast-container`, `candor-tab-panel`).

## Changes
- `README.md` — two current-state count refs 34 → 37.
- `web-components/README.md` — count 34 → 37, **and** the "What's included" category table gains the three shipped components it was missing: `candor-code` (Typography), `candor-autocomplete` (Form), `candor-tone-picker` (Data). The corrected table now enumerates exactly 37 primary tags.
- `CLAUDE.md` — the registration note ("register all N tags") synced 34 → 37 to match the count set in #195.

## Intentionally left at 34
- `CHANGELOG.md` 4.0.0 entry (historical — 34 was correct at that release).
- `docs/A11Y-AUDIT.md` (audit scope).
- `PUBLISH-HANDOFF.md` ("34+ exports" — still true).
- `candor-article.stories.ts` demo prose.

## Flagged, not touched (want a call before editing)
- `docs/ACCESSIBILITY-CONFORMANCE.md` says "The 34 Lit custom elements…" — a formal conformance statement; bumping it asserts the 3 new components carry the same conformance (true for autocomplete/tone-picker/code, but worth a deliberate decision).
- `CLAUDE.md` "87 pairings covering all 34 WC components" — a `pairings.json` coverage metric, not the component count; needs a real audit of `pairings.json` rather than a blind number bump.

Docs-only; no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwsLArMppueSMc4cUHuk9b