### PR TITLE
ci(chromatic): auto-accept on main so the baseline survives a squash merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,23 @@ jobs:
       # Official Chromatic action. TurboSnap (onlyChanged) snapshots only the
       # stories affected by the diff — full builds still run on main and when
       # Chromatic detects a dependency/config change that invalidates the graph.
-      # PRs report diffs without blocking; main fails on unreviewed changes.
+      #
+      # The PR build is the review gate: it reports diffs without blocking, and
+      # accepting them there is what approves them. The main build only records
+      # that approval as the new baseline, so it auto-accepts.
+      #
+      # main cannot re-check the diffs itself. Candor merges squash-only, so the
+      # branch commits are not ancestors of the commit that lands on main, and
+      # Chromatic — which finds a baseline by walking git ancestry — cannot reach
+      # the accepted PR build. It falls back to main's previous build and reports
+      # every already-approved diff as new. Failing main on that does not catch
+      # unreviewed changes; it re-asks a question answered one commit earlier and
+      # fails because nobody answers it twice. That left main red from Aug 1 to
+      # Aug 3, which is worse than ungated: a real breakage on main was
+      # indistinguishable from the standing failure (#232).
       - uses: chromaui/action@v18
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
           exitZeroOnChanges: ${{ github.event_name == 'pull_request' }}
+          autoAcceptChanges: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
Two lines of config. The reasoning is the reason this isn't a one-liner PR description.

## What was wrong

The chromatic job failed on **every push to `main` from Aug 1 to Aug 3** — three consecutive merges. Not a visual regression.

```
Commit 'aab199d' on branch 'main'; found 1 parent build and 20 changed files
✖ Found 28 visual changes
```

Those 28 were reviewed and accepted on build 122, the PR build for #227, one commit earlier.

Candor merges **squash-only**, so a PR branch's commits are never ancestors of the commit that lands on `main`. Chromatic finds a baseline by walking git ancestry — with those commits gone it cannot reach the accepted build, falls back to `main`'s previous build, and reports every approved diff as new. `exitZeroOnChanges: false` on push turns that into a failure.

So the gate could only ever fire on changes that were approved one commit earlier. It never had access to an unreviewed change on `main`; the merge strategy guarantees it can't.

## Why this mattered more than a red badge

`main` being permanently red meant its CI status carried **no information** — a real breakage would have looked exactly like the standing failure. That is the same defect shape as #218 and #223: a guard that appears to be checking something and isn't. Alongside that, every merge needed a second manual acceptance in the Chromatic UI, and snapshot quota was spent twice on identical diffs.

## The fix

```yaml
exitZeroOnChanges: ${{ github.event_name == 'pull_request' }}
autoAcceptChanges: ${{ github.ref == 'refs/heads/main' }}
```

Review is unchanged. The **PR build stays the review gate** — that is where diffs are read and where accepting them approves them. The `main` build only records that approval as the new baseline, which is the one thing it is actually positioned to do.

`github.ref` is `refs/pull/N/merge` on pull_request events, so auto-accept is off for PRs — verified by this PR's own chromatic run.

The `ci.yml` comment block is rewritten too; the old one documented the unreachable intent (*"main fails on unreviewed changes"*), which is what made the config look correct.

## Considered and rejected

Dropping squash-only merge would also fix it by preserving the ancestry Chromatic needs. Not worth it — one commit per issue on `main` is a deliberate choice, and rewriting the merge strategy to serve a CI detail is the wrong direction.

## Verification

- `ci.yml` parses; all five jobs (`build-tokens`, `gamut`, `build-web-components`, `accessibility`, `chromatic`) intact
- This PR's chromatic run must still **report** diffs without auto-accepting — that is the check that `github.ref` gates correctly
- No CHANGELOG entry: CI-only, matching the precedent set by #200

closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DznZDd9DycKdELUyVkDYG
