### PR TITLE
chore: skip chromatic on Dependabot runs, and batch the dev-dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,27 @@ jobs:
 
   chromatic:
     runs-on: ubuntu-latest
+    # GitHub withholds repository secrets from Dependabot-triggered runs, so on a
+    # Dependabot PR this job can only fail with "Missing project token" — 15
+    # seconds in, having snapshotted nothing. That red says nothing about the
+    # bump, and a check that always fails for a reason unrelated to the change is
+    # noise that trains people to ignore the column.
+    #
+    # Skipping it does NOT mean dependency updates go un-diffed. It means they
+    # are not diffed *here*: the policy is that Dependabot PRs are notifications,
+    # and the updates land through a human-authored batch PR where the secret
+    # exists and the visual diff gets a real review. Read this as the other half
+    # of the skip, because merging a Dependabot PR directly would bypass the
+    # visual gate entirely — autoAcceptChanges below is true on main, so whatever
+    # a Storybook bump changed would become the new baseline with nobody having
+    # looked at it. Batching also costs one Chromatic build per round instead of
+    # one per bump.
+    #
+    # The alternative was a Dependabot-scoped copy of the token. Rejected: `npm
+    # ci` runs dependency install scripts in this same job, so a compromised
+    # version of any transitive dev dependency — the exact thing these PRs
+    # change — would execute alongside a write-scoped project token.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed (tooling)
+
+- **The `chromatic` CI job no longer runs on Dependabot pull requests.** GitHub withholds repository secrets from Dependabot-triggered runs, so the job could only ever fail there with `✖ Missing project token`, ~15 seconds in, having snapshotted nothing — a red check reporting on the absence of a credential rather than on the bump. It was never blocking (`chromatic` is deliberately not a required status check), but a column that is always red for a reason unrelated to the change is a column people learn to skip.
+
+  Recorded alongside the skip, because the skip alone would be a hole: `autoAcceptChanges` is true on `main`, so a Dependabot PR merged directly would have its rendering changes adopted as the new baseline with nobody having reviewed them. The policy the skip depends on is that **Dependabot PRs are notifications** — updates land through a human-authored batch PR, where the secret exists and the visual diff gets a real review. A Dependabot-scoped copy of the token was considered and rejected: `npm ci` runs dependency install scripts in that same job, so a compromised version of any transitive dev dependency — precisely what these PRs change — would execute next to a write-scoped project token.
+
+### Changed (tooling)
+
+- **Dev-dependency updates batched:** Storybook 10.3.5/10.4.4 → 10.5.6 (`storybook`, `@storybook/addon-a11y`, `@storybook/addon-docs`, `@storybook/addon-themes`, `@storybook/web-components-vite`), `@chromatic-com/storybook` 5.1.2 → 5.2.1, `@playwright/test` 1.59.1 → 1.62.1, `vite-plugin-dts` 5.0.0 → 5.0.3. Supersedes Dependabot #251, #205 and #204. Verified: `typecheck`, `audit:tokens` (180 colours in gamut, artifact unchanged), `audit:contrast` (238 enforced pairings, 0 failing, no drift), `test:playwright` (28/28), `build:tokens`, `build:wc`, `build-storybook`, `npm audit` 0 vulnerabilities. `typescript` 5.9.3 → 7.0.2 (#203) is deliberately not in this batch — a major belongs in its own PR.
+
 ## [5.0.0] - 2026-08-05
 
 ### Breaking changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,19 +21,19 @@
         "typescript": "~5.9.3"
       },
       "devDependencies": {
-        "@chromatic-com/storybook": "^5.0.2",
+        "@chromatic-com/storybook": "^5.2.1",
         "@phosphor-icons/web": "^2.1.2",
-        "@playwright/test": "^1.57.0",
-        "@storybook/addon-a11y": "^10.1.4",
-        "@storybook/addon-docs": "^10.1.4",
-        "@storybook/addon-themes": "^10.3.1",
-        "@storybook/web-components-vite": "^10.4.4",
+        "@playwright/test": "^1.62.1",
+        "@storybook/addon-a11y": "^10.5.6",
+        "@storybook/addon-docs": "^10.5.6",
+        "@storybook/addon-themes": "^10.5.6",
+        "@storybook/web-components-vite": "^10.5.6",
         "@types/node": "^24.13.3",
         "chromatic": "^18.0.1",
         "sass": "^1.101.0",
-        "storybook": "^10.1.4",
+        "storybook": "^10.5.6",
         "vite": "^8.1.4",
-        "vite-plugin-dts": "^5.0.0"
+        "vite-plugin-dts": "^5.0.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -49,7 +49,6 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -65,7 +64,6 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -76,21 +74,19 @@
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@chromatic-com/storybook": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-5.1.2.tgz",
-      "integrity": "sha512-H/hgvwC3E+OtseP2OT2QYUJH2VfnzT6wM3pWOkaNV6g7QI+VUdWJbeJ3o2jFqvEPQNqzhQKWDOlvM4lu+7is6g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-5.2.1.tgz",
+      "integrity": "sha512-z6I7NJk/0VngA64y5TNYaB4Hc2X8+90n4op6lBt9PvWk5TmIlFLDqdX33rlrwbNRkkYijVgA/wO04rVYXi5Mlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@neoconfetti/react": "^1.0.0",
-        "chromatic": "^13.3.4",
-        "filesize": "^10.0.12",
+        "chromatic": "16.10.0",
         "jsonfile": "^6.1.0",
         "strip-ansi": "^7.1.0"
       },
@@ -99,29 +95,36 @@
         "yarn": ">=1.22.18"
       },
       "peerDependencies": {
-        "storybook": "^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0"
+        "storybook": "^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0"
       }
     },
     "node_modules/@chromatic-com/storybook/node_modules/chromatic": {
-      "version": "13.3.5",
-      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-13.3.5.tgz",
-      "integrity": "sha512-MzPhxpl838qJUo0A55osCF2ifwPbjcIPeElr1d4SHcjnHoIcg7l1syJDrAYK/a+PcCBrOGi06jPNpQAln5hWgw==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-16.10.0.tgz",
+      "integrity": "sha512-nFsztmnu7rFiGafUJgXvLUNpqmRylz92eNvzBoJNTKKQj4EQUyxznwnfpf1dTs7hXtWD8JwcH92jADydaHA1sw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
       "bin": {
-        "chroma": "dist/bin.js",
-        "chromatic": "dist/bin.js",
-        "chromatic-cli": "dist/bin.js"
+        "chroma": "dist/bin.cjs",
+        "chromatic": "dist/bin.cjs",
+        "chromatic-cli": "dist/bin.cjs"
       },
       "peerDependencies": {
         "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
-        "@chromatic-com/playwright": "^0.*.* || ^1.0.0"
+        "@chromatic-com/playwright": "^0.*.* || ^1.0.0",
+        "@chromatic-com/vitest": "^0.*.* || ^1.0.0"
       },
       "peerDependenciesMeta": {
         "@chromatic-com/cypress": {
           "optional": true
         },
         "@chromatic-com/playwright": {
+          "optional": true
+        },
+        "@chromatic-com/vitest": {
           "optional": true
         }
       }
@@ -1786,19 +1789,19 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2118,9 +2121,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2147,9 +2150,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.3.5.tgz",
-      "integrity": "sha512-5k6lpgfIeLxvNhE8v3wEzdiu73ONKjF4gmH1AHvfqYd8kIVzQJai0KCDxgvqNncXHQhIWkaf1fg6+9hKaYJyaw==",
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.5.6.tgz",
+      "integrity": "sha512-pMqbmtvkIgb7/kVE2BTNovGhSerRXWsVag62zpwQe0SwYYkgN+1Q9h4TYuIe2+npGkxgwALCjwtqkcnpOoND+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2161,20 +2164,20 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.5"
+        "storybook": "^10.5.6"
       }
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.3.5.tgz",
-      "integrity": "sha512-WuHbxia/o5TX4Rg/IFD0641K5qId/Nk0dxhmAUNoFs5L0+yfZUwh65XOBbzXqrkYmYmcVID4v7cgDRmzstQNkA==",
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.5.6.tgz",
+      "integrity": "sha512-zyUJBrrpC9NTrmsREaVFNr+9WW6pikJtmRvo7GgZGqthEyhjQKSarHrW0aNWkwae2ep3jp1CZi8vIUVG1Dnp0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "10.3.5",
-        "@storybook/icons": "^2.0.1",
-        "@storybook/react-dom-shim": "10.3.5",
+        "@storybook/csf-plugin": "10.5.6",
+        "@storybook/icons": "^2.0.2",
+        "@storybook/react-dom-shim": "10.5.6",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -2184,84 +2187,55 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.3.5"
-      }
-    },
-    "node_modules/@storybook/addon-themes": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.3.5.tgz",
-      "integrity": "sha512-Mv+C7GuZ0MhGRx5C+rv8sCEjgYsDTLBvq68101V0s8Vwh3gKd6W9cbS31HoOeLAiIMiPPZ8C1iWudA3Oumdtlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^10.3.5"
-      }
-    },
-    "node_modules/@storybook/builder-vite": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.4.4.tgz",
-      "integrity": "sha512-VyuZ4mEvhhVXjJa1qXMWKH8ohnas0rgEuJDf6u4aJ54XeENFebPUEAHde1Qo2PflJ4rUdVdXieOZzKbYwP5RAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/csf-plugin": "10.4.4",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^10.4.4",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@storybook/builder-vite/node_modules/@storybook/csf-plugin": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.4.tgz",
-      "integrity": "sha512-1mzZyAwVUmAcw4WEUsJDVdSupkJf+Kf/f5uNAs4RzlBXA75P8YRkDKAb2EoMwsB5URiXFi9XoeAN/vWke0G6+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unplugin": "^2.3.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "esbuild": "*",
-        "rollup": "*",
-        "storybook": "^10.4.4",
-        "vite": "*",
-        "webpack": "*"
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.6"
       },
       "peerDependenciesMeta": {
-        "esbuild": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        },
-        "webpack": {
+        "@types/react": {
           "optional": true
         }
       }
     },
+    "node_modules/@storybook/addon-themes": {
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.5.6.tgz",
+      "integrity": "sha512-fIzu2f6xPh/mtOBUU9TnjSoO3qUIF57AVES9HX4dfhjtbz9lWd+EhNd65nZfmTXxKsS32x/7/aXDTHtuP/ObwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.6"
+      }
+    },
+    "node_modules/@storybook/builder-vite": {
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.6.tgz",
+      "integrity": "sha512-Ts8EohKPj8okDPCkueeKVN+IRGNpI3LuddsFGupqraRvK6aRWawDKA28uc0PlsLCLWbMkMsGVw+IpFXfmoLJgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "10.5.6",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.6",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/@storybook/csf-plugin": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.3.5.tgz",
-      "integrity": "sha512-qlEzNKxOjq86pvrbuMwiGD/bylnsXk1dg7ve0j77YFjEEchqtl7qTlrXvFdNaLA89GhW6D/EV6eOCu/eobPDgw==",
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.5.6.tgz",
+      "integrity": "sha512-PJLyOmcKe1OZDBw7RaGX/gjuiJuVfS5pVgc4W2RnHYOFpU6F5Bv9+9MqQwp0i7tWZBWc4fsCJudgVqwgjuTROA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2274,7 +2248,7 @@
       "peerDependencies": {
         "esbuild": "*",
         "rollup": "*",
-        "storybook": "^10.3.5",
+        "storybook": "^10.5.6",
         "vite": "*",
         "webpack": "*"
       },
@@ -2312,9 +2286,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.3.5.tgz",
-      "integrity": "sha512-Gw8R7XZm0zSUH0XAuxlQJhmizsLzyD6x00KOlP6l7oW9eQHXGfxg3seNDG3WrSAcW07iP1/P422kuiriQlOv7g==",
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.5.6.tgz",
+      "integrity": "sha512-dV3oOHc5ImggxEqeIiUj4vvnQO5SKScFtqAkxgIWLju1wiSZSIqQ5Q4Mp12Rhs9hQrjF039DueH7f2xJJZfvSw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2322,15 +2296,25 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.3.5"
+        "storybook": "^10.5.6"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@storybook/web-components": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/@storybook/web-components/-/web-components-10.4.4.tgz",
-      "integrity": "sha512-lA++1eyjTUbRbOV7q0b/EBZBZCFSezI/ybYFHLNuGMvJzebxibp2xz/V3WWCRnjWXV5TrIzdtN9V5bO+TKDR7g==",
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/web-components/-/web-components-10.5.6.tgz",
+      "integrity": "sha512-Q9HMv2ZQCaeVu6kq/7kVBUPIm40YdAutCnfMDKbVciMEzNnm561NI+qNVmtvy75/GZxsknxzGzGn1k7+f4WFYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2344,25 +2328,25 @@
       },
       "peerDependencies": {
         "lit": "^2.0.0 || ^3.0.0",
-        "storybook": "^10.4.4"
+        "storybook": "^10.5.6"
       }
     },
     "node_modules/@storybook/web-components-vite": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/@storybook/web-components-vite/-/web-components-vite-10.4.4.tgz",
-      "integrity": "sha512-Gq8oq7hXYU1Q/+yaykKXOuo6fd/HCJDGQ2e3N3F3vLRL33NXvlWpH1G3OvyVe268dc+V6C8AXm6WxwUXCUZydQ==",
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/web-components-vite/-/web-components-vite-10.5.6.tgz",
+      "integrity": "sha512-EW/o38khp7HVqjx62YTS/jZDATqqmN77iTWAT2q2LrSpfhgkEF5ULhmf0gLgQmbx4H0PI0xiTgg/KGrXACQaFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-vite": "10.4.4",
-        "@storybook/web-components": "10.4.4"
+        "@storybook/builder-vite": "10.5.6",
+        "@storybook/web-components": "10.5.6"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.4.4",
+        "storybook": "^10.5.6",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
@@ -2372,7 +2356,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2444,8 +2427,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2466,9 +2448,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2601,9 +2583,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2619,7 +2601,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2894,8 +2875,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -2961,9 +2941,9 @@
       "license": "MIT"
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
       "dev": true,
       "license": "MIT"
     },
@@ -2983,16 +2963,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/filesize": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.6.tgz",
-      "integrity": "sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 10.4.0"
       }
     },
     "node_modules/fsevents": {
@@ -3116,8 +3086,14 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
@@ -3444,9 +3420,9 @@
       }
     },
     "node_modules/local-pkg": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
-      "integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3474,7 +3450,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3720,35 +3695,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {
@@ -3801,7 +3776,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3817,7 +3791,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3870,8 +3843,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -4027,27 +3999,29 @@
       }
     },
     "node_modules/storybook": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.4.tgz",
-      "integrity": "sha512-Nn0qFRxU5fyABa6dGRftfL3lz0Y+HkKOaAkfytF8S4Q2K6Szwwq7TwPAEs3Wsj8hBQbYhsobrKADcPsyXQpJaA==",
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.6.tgz",
+      "integrity": "sha512-VhYwqxPySa24CVXKoWD6gCZXx9//DTmo43YpusGuAoHDYj5Osjt8wuBRQVeGoaLUWnHiPWv8S+GYHrJEaBM6Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.2",
-        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "6.9.1",
         "@testing-library/user-event": "^14.6.1",
         "@vitest/expect": "3.2.4",
         "@vitest/spy": "3.2.4",
         "@webcontainer/env": "^1.1.1",
-        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0",
+        "jsonc-parser": "^3.3.1",
         "open": "^10.2.0",
         "oxc-parser": "^0.127.0",
         "oxc-resolver": "^11.19.1",
         "recast": "^0.23.5",
         "semver": "^7.7.3",
         "use-sync-external-store": "^1.5.0",
-        "ws": "^8.18.0"
+        "ws": "^8.21.1"
       },
       "bin": {
         "storybook": "dist/bin/dispatcher.js"
@@ -4059,7 +4033,7 @@
       "peerDependencies": {
         "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "prettier": "^2 || ^3",
-        "vite-plus": "^0.1.15"
+        "vite-plus": "^0.1.15 || ^0.2.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4229,9 +4203,9 @@
       }
     },
     "node_modules/unplugin-dts": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unplugin-dts/-/unplugin-dts-1.0.0.tgz",
-      "integrity": "sha512-qz+U1lCscwq+t8Mkaxy5Esa7IQ5wWV18b4mnioOXSdnPaNiJ0+qgE3I+KL6UkXYZWxxGo2qdGone8LEQ52Sfkw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unplugin-dts/-/unplugin-dts-1.0.3.tgz",
+      "integrity": "sha512-/GR887wfG4r1cWyt1UZsLRuMIjsmEbGkS9yJrz+0dsToHAYUD5CTyP3JMGVLv25j9K0mJcwAVvZno/aTuSUvNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4247,7 +4221,7 @@
       "peerDependencies": {
         "@microsoft/api-extractor": ">=7",
         "@rspack/core": "^1",
-        "@vue/language-core": "~3.1.5",
+        "@vue/language-core": "^3.1.5",
         "esbuild": "*",
         "rolldown": "*",
         "rollup": ">=3",
@@ -4371,13 +4345,13 @@
       }
     },
     "node_modules/vite-plugin-dts": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-5.0.0.tgz",
-      "integrity": "sha512-VLNAUttBq7pLxxL/m/ztjd5zj5yiviiC7ijfPFVLK5c45FLcibvieBsdjSka3a4ag1qdrAF9K3OysH4/lW+rPQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-5.0.3.tgz",
+      "integrity": "sha512-gIth6NdCEHWPiiRMCK3N6C8WjvdsrtEQrmsiG8h6Ov+lFP+b07Y+wcs9H0H7n146l0PDTYK4cQN1vgeG1pMdRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "unplugin-dts": "1.0.0"
+        "unplugin-dts": "1.0.3"
       },
       "peerDependencies": {
         "@microsoft/api-extractor": ">=7",
@@ -4411,9 +4385,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -62,18 +62,18 @@
     "typescript": "~5.9.3"
   },
   "devDependencies": {
-    "@chromatic-com/storybook": "^5.0.2",
+    "@chromatic-com/storybook": "^5.2.1",
     "@phosphor-icons/web": "^2.1.2",
-    "@playwright/test": "^1.57.0",
-    "@storybook/addon-a11y": "^10.1.4",
-    "@storybook/addon-docs": "^10.1.4",
-    "@storybook/addon-themes": "^10.3.1",
-    "@storybook/web-components-vite": "^10.4.4",
+    "@playwright/test": "^1.62.1",
+    "@storybook/addon-a11y": "^10.5.6",
+    "@storybook/addon-docs": "^10.5.6",
+    "@storybook/addon-themes": "^10.5.6",
+    "@storybook/web-components-vite": "^10.5.6",
     "@types/node": "^24.13.3",
     "chromatic": "^18.0.1",
     "sass": "^1.101.0",
-    "storybook": "^10.1.4",
+    "storybook": "^10.5.6",
     "vite": "^8.1.4",
-    "vite-plugin-dts": "^5.0.0"
+    "vite-plugin-dts": "^5.0.3"
   }
 }


### PR DESCRIPTION
Two related changes: a CI policy fix for a check that could never pass on Dependabot, and the dependency batch that policy depends on.

## 1. `chromatic` is skipped on Dependabot runs

Every Dependabot PR has been failing `chromatic` with `✖ Missing project token`, ~15s in, having snapshotted nothing. GitHub withholds repository secrets from Dependabot-triggered runs, so this was never about the bump. Nothing was blocked — `chromatic` is deliberately not a required status check — and no Chromatic snapshots were consumed. But a column that is always red for a reason unrelated to the change is a column people learn to skip, which is the failure mode 5.0.0 spent a release closing.

**The skip alone would be a hole, so the policy is recorded next to it.** `autoAcceptChanges` is true on `main` (the #232 fix), so a Dependabot PR merged directly would have whatever it changed visually adopted as the new baseline with nobody having looked. The skip is therefore paired with: **Dependabot PRs are notifications**; updates land through a human-authored batch PR, where the secret exists and the diff gets a real review.

**The alternative was a Dependabot-scoped copy of the token, and it is rejected in the comment:** `npm ci` runs dependency install scripts in that same job, so a compromised version of any transitive dev dependency — precisely what these PRs change — would execute alongside a write-scoped project token.

## 2. The batch

Supersedes **#251**, **#205**, **#204**. One PR, one Chromatic build for the round.

| Package | From | To |
| --- | --- | --- |
| `storybook`, `@storybook/addon-a11y`, `@storybook/addon-docs`, `@storybook/addon-themes`, `@storybook/web-components-vite` | 10.3.5 / 10.4.4 | **10.5.6** |
| `@chromatic-com/storybook` | 5.1.2 | 5.2.1 |
| `@playwright/test` | 1.59.1 | 1.62.1 |
| `vite-plugin-dts` | 5.0.0 | 5.0.3 |

npm resolved the Storybook group to 10.5.6 rather than Dependabot's 10.5.5 — the current release of the same minor.

**`typescript` 5.9.3 → 7.0.2 (#203) is deliberately excluded.** A compiler major belongs in its own PR with its own evaluation, not in a routine batch.

## Verification

Run locally before pushing:

- `typecheck` ✅
- `audit:tokens` ✅ — 180 authored colours (135 distinct) all renderable; DTCG artifact byte-identical
- `audit:contrast` ✅ — 238 enforced pairings / 0 failing; pairing notes, token descriptions and story prose all `no drift`; 4 declared chrome/icon and 0 unaccounted below the 14px floor
- `test:playwright` ✅ — 28/28
- `build:tokens` ✅ — committed `tokens/` output unchanged
- `build:wc` ✅
- `build-storybook` ✅ — the real risk in a 10.3 → 10.5 bump
- `npm audit` ✅ — 0 vulnerabilities

**The Chromatic build on this PR is the review gate** — it is the visual check the three superseded PRs could not run.
