### PR TITLE
fix(packaging): declare culori on web-components, drop build tools from tokens, and gate both

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,15 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run build:wc
+      # Gates what the published packages *declare* against what their built
+      # artifacts *reference*. It lives here rather than in the `audit` job
+      # because it reads web-components/dist, which is gitignored and therefore
+      # only exists after the build step above.
+      #
+      # An undeclared import cannot fail anywhere else: this repo hoists every
+      # package into one node_modules, so a missing declaration resolves fine
+      # here and breaks only in a consumer's clean install (#254).
+      - run: npm run audit:packaging
 
   accessibility:
     # Keyboard / focus / ARIA behaviour the visual gate (Chromatic) can't see.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`@candor-design/web-components` now declares its `culori` dependency, and `@candor-design/tokens` no longer ships the TypeScript compiler (#254).** Two mistakes that had been cancelling each other out.
+
+  `web-components/dist/tone-data.js` — the `./tone-data` entry point — contains a bare `import … from "culori"` by design (`external: ['culori']`, so consumers who already use culori don't get a second copy). But the package declared **no dependencies at all**, so that import resolved only because `@candor-design/tokens` carried `culori` in *its* runtime dependencies, where it did not belong. Verified by negative control: with culori absent, `import '@candor-design/web-components/tone-data'` fails with `ERR_MODULE_NOT_FOUND`. Removing it from `tokens` without this fix would have published a broken entry point.
+
+  `@candor-design/tokens` ships `files: ["tokens"]` — four CSS/JSON artifacts — and declared ten runtime dependencies. `typescript`, `lit` and `tslib` moved to `devDependencies`; `@standard-schema/spec` was removed outright (its only occurrence anywhere in the repo was its own `package.json` line). The five `@fontsource*` entries stay: `candor-fonts.css` `@import`s them by bare specifier, so a consumer's bundler must resolve them. A clean install of both packages now resolves to the five font packages plus culori, with no compiler.
+
+  Also corrected: the tone-picker story described culori as "a peer dependency of the `/tone-data` entry point" — nothing declared such a peer — and said the CIEDE2000 labels were "computed at build time", when `buildGamutRows` runs at module top level and computes them on import.
+
+- **Added `npm run audit:packaging`, gating what the published packages declare against what their built artifacts reference.** Runs in CI in the `build-web-components` job, after `build:wc`, since it reads the gitignored `web-components/dist`.
+
+  Two directions, because the bug had two halves: **undeclared** (a bare specifier in a published artifact that no manifest declares — breaks a consumer's install) and **unused** (a declared runtime dependency no published artifact references — how a compiler ends up in a stylesheet's dependency tree). `peerDependencies` are exempt from the unused check, since a peer is a claim about consumer coordination rather than about what the bundle imports. Verified by tripwire in both directions.
+
+  This is the gap that let #254 exist: `build:tokens` validates the artifacts, `audit:*` validate colour, `typecheck` and `test:playwright` run against source — **nothing read a manifest.** And an undeclared import cannot fail locally, because this repo hoists every package into one `node_modules`; it surfaces only in a clean install somewhere else. No allowlist, per the `audit:tokens` precedent — inspection found no legitimate exception in either direction.
+
 ### Fixed (tooling)
 
 - **The `chromatic` CI job no longer runs on Dependabot pull requests.** GitHub withholds repository secrets from Dependabot-triggered runs, so the job could only ever fail there with `✖ Missing project token`, ~15 seconds in, having snapshotted nothing — a red check reporting on the absence of a credential rather than on the bump. It was never blocking (`chromatic` is deliberately not a required status check), but a column that is always red for a reason unrelated to the change is a column people learn to skip.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,7 @@
         "@fontsource-variable/noto-serif": "^5.2.9",
         "@fontsource-variable/roboto-flex": "^5.2.8",
         "@fontsource-variable/roboto-mono": "^5.2.8",
-        "@fontsource/atkinson-hyperlegible": "^5.2.8",
-        "@standard-schema/spec": "^1.0.0",
-        "culori": "^4.0.2",
-        "lit": "^3.3.2",
-        "tslib": "^2.8.1",
-        "typescript": "~5.9.3"
+        "@fontsource/atkinson-hyperlegible": "^5.2.8"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^5.2.1",
@@ -30,8 +25,12 @@
         "@storybook/web-components-vite": "^10.5.6",
         "@types/node": "^24.13.3",
         "chromatic": "^18.0.1",
+        "culori": "^4.0.2",
+        "lit": "^3.3.2",
         "sass": "^1.101.0",
         "storybook": "^10.5.6",
+        "tslib": "^2.8.1",
+        "typescript": "~5.9.3",
         "vite": "^8.1.4",
         "vite-plugin-dts": "^5.0.3"
       }
@@ -704,12 +703,14 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
       "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
       "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
@@ -2143,12 +2144,6 @@
         }
       }
     },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
-    },
     "node_modules/@storybook/addon-a11y": {
       "version": "10.5.6",
       "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.5.6.tgz",
@@ -2486,6 +2481,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
@@ -2774,6 +2770,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/culori/-/culori-4.0.2.tgz",
       "integrity": "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -3392,6 +3389,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
       "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -3403,6 +3401,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
       "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0",
@@ -3414,6 +3413,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
       "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -4147,12 +4147,14 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "release:major": "npm version major && git push origin main --follow-tags",
     "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",
     "audit:tokens": "node scripts/export-tokens-dtcg.js",
-    "audit:contrast": "node scripts/check-contrast.js"
+    "audit:contrast": "node scripts/check-contrast.js",
+    "audit:packaging": "node scripts/check-package-deps.js"
   },
   "repository": {
     "type": "git",
@@ -54,12 +55,7 @@
     "@fontsource-variable/noto-serif": "^5.2.9",
     "@fontsource-variable/roboto-flex": "^5.2.8",
     "@fontsource-variable/roboto-mono": "^5.2.8",
-    "@fontsource/atkinson-hyperlegible": "^5.2.8",
-    "@standard-schema/spec": "^1.0.0",
-    "culori": "^4.0.2",
-    "lit": "^3.3.2",
-    "tslib": "^2.8.1",
-    "typescript": "~5.9.3"
+    "@fontsource/atkinson-hyperlegible": "^5.2.8"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.2.1",
@@ -71,8 +67,12 @@
     "@storybook/web-components-vite": "^10.5.6",
     "@types/node": "^24.13.3",
     "chromatic": "^18.0.1",
+    "culori": "^4.0.2",
+    "lit": "^3.3.2",
     "sass": "^1.101.0",
     "storybook": "^10.5.6",
+    "tslib": "^2.8.1",
+    "typescript": "~5.9.3",
     "vite": "^8.1.4",
     "vite-plugin-dts": "^5.0.3"
   }

--- a/scripts/check-package-deps.js
+++ b/scripts/check-package-deps.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Gates what the *published* packages declare against what their *built
+ * artifacts* actually reference.
+ *
+ * The bug this exists for (#254): `@candor-design/web-components/tone-data`
+ * shipped a bare `import ... from "culori"` while its package.json declared no
+ * dependencies at all. It resolved anyway, because `@candor-design/tokens`
+ * happened to carry culori in its own runtime dependencies — where it did not
+ * belong, alongside `lit`, `tslib` and the TypeScript compiler, in a package
+ * whose `files` is `["tokens"]` and which ships four CSS/JSON artifacts.
+ *
+ * Two mistakes cancelling out, and every existing check looked straight past
+ * them: build:tokens validates the artifacts, audit:* validate colour,
+ * typecheck and test:playwright run against source. Nothing read a manifest.
+ * That is the whole reason this file exists — `files` and `dependencies` were
+ * each individually plausible, so a human reading either one saw nothing wrong.
+ *
+ * Two directions, because the bug had two halves:
+ *
+ *   missing — a bare specifier in a published artifact that no manifest
+ *             declares. This is the half that breaks a consumer's install, and
+ *             it is invisible in this repo because the root node_modules has
+ *             everything. It only surfaces in a clean install elsewhere.
+ *
+ *   unused  — a declared runtime dependency that no published artifact
+ *             references. Never breaks anything; it is how a compiler ends up
+ *             in the dependency tree of a stylesheet.
+ *
+ * `peerDependencies` are deliberately exempt from the unused check.
+ * `@candor-design/tokens` is a peer of the web-components package for the CSS
+ * custom properties, which no JS import references — a peer is a statement
+ * about consumer coordination, not about what the bundle imports.
+ *
+ * There is deliberately no allowlist. Inspection at #254 found no legitimate
+ * exception in either direction, and an exemption with no user is only an
+ * escape hatch waiting to be used.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+
+/**
+ * Strip `/* … *\/` block comments before scanning.
+ *
+ * Not optional: `tokens/candor-tokens.css` opens with a usage example reading
+ * `@import url("candor-tokens.css")`, and matching that would report the
+ * package's own documentation as an undeclared dependency. The same shape as the
+ * `12px-ok:` marker rule in CLAUDE.md — prose that demonstrates a syntax must
+ * not be read as an instance of it.
+ *
+ * CSS has no line comments, so this is complete for the token artifacts. The JS
+ * artifacts are minified, which removes ordinary comments; `//` is left alone
+ * deliberately, since stripping it would eat the `//` in every `https://` URL.
+ */
+function stripBlockComments(code) {
+  return code.replace(/\/\*[\s\S]*?\*\//g, ' ');
+}
+
+/** Bare specifier = not relative, not absolute, not a node: builtin. */
+function isBare(spec) {
+  return !spec.startsWith('.') && !spec.startsWith('/') && !spec.startsWith('node:');
+}
+
+/** `@scope/name/deep/path` → `@scope/name`; `name/deep` → `name`. */
+function packageName(spec) {
+  const parts = spec.split('/');
+  return spec.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+}
+
+/** ESM/CJS bare specifiers in built JS: import, export-from, require, dynamic import. */
+function jsSpecifiers(code) {
+  const found = new Set();
+  const patterns = [
+    /(?:^|[^\w$])(?:import|export)[\s\S]{0,200}?from\s*["']([^"']+)["']/g,
+    /(?:^|[^\w$])import\s*["']([^"']+)["']/g,
+    /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+  ];
+  for (const re of patterns) {
+    for (const m of code.matchAll(re)) if (isBare(m[1])) found.add(packageName(m[1]));
+  }
+  return found;
+}
+
+/** Bare specifiers in CSS `@import "…"` / `url(…)`. */
+function cssSpecifiers(code) {
+  const found = new Set();
+  for (const m of code.matchAll(/@import\s+(?:url\()?\s*["']([^"']+)["']/g)) {
+    if (isBare(m[1])) found.add(packageName(m[1]));
+  }
+  return found;
+}
+
+function walk(dir, test) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const p = path.join(dir, e.name);
+    return e.isDirectory() ? walk(p, test) : test(p) ? [p] : [];
+  });
+}
+
+const targets = [
+  {
+    label: '@candor-design/tokens',
+    manifest: path.join(ROOT, 'package.json'),
+    // The published surface is `files: ["tokens"]` — the CSS/JSON artifacts only.
+    files: () => walk(path.join(ROOT, 'tokens'), (p) => p.endsWith('.css') || p.endsWith('.json')),
+    extract: (p, code) => (p.endsWith('.css') ? cssSpecifiers(code) : new Set()),
+    buildWith: 'npm run build:tokens',
+  },
+  {
+    label: '@candor-design/web-components',
+    manifest: path.join(ROOT, 'web-components', 'package.json'),
+    files: () =>
+      walk(path.join(ROOT, 'web-components', 'dist'), (p) => p.endsWith('.js') || p.endsWith('.cjs')),
+    extract: (_p, code) => jsSpecifiers(code),
+    buildWith: 'npm run build:wc',
+  },
+];
+
+let failed = false;
+
+for (const t of targets) {
+  const pkg = JSON.parse(fs.readFileSync(t.manifest, 'utf8'));
+  const declared = new Set(Object.keys(pkg.dependencies ?? {}));
+  const peers = new Set(Object.keys(pkg.peerDependencies ?? {}));
+  const files = t.files();
+
+  console.log(`\n${t.label}`);
+
+  if (files.length === 0) {
+    console.log(`  ✖ no built artifacts found — run \`${t.buildWith}\` first`);
+    failed = true;
+    continue;
+  }
+
+  const referenced = new Map(); // package name → the artifact that referenced it
+  for (const f of files) {
+    const code = stripBlockComments(fs.readFileSync(f, 'utf8'));
+    for (const spec of t.extract(f, code)) {
+      if (!referenced.has(spec)) referenced.set(spec, path.relative(ROOT, f).replace(/\\/g, '/'));
+    }
+  }
+
+  // A self-reference is how the artifact documents its own public import path,
+  // not a dependency on itself.
+  referenced.delete(pkg.name);
+
+  const missing = [...referenced].filter(([name]) => !declared.has(name) && !peers.has(name));
+  const unused = [...declared].filter((name) => !referenced.has(name));
+
+  console.log(
+    `  ${files.length} artifact(s), ${referenced.size} bare specifier(s), ` +
+      `${declared.size} dependency/-ies, ${peers.size} peer(s)`,
+  );
+
+  for (const [name, where] of missing) {
+    console.log(`  ✖ undeclared: "${name}" is imported by ${where} but is not a dependency or peer`);
+    failed = true;
+  }
+  for (const name of unused) {
+    console.log(`  ✖ unused: "${name}" is a runtime dependency but no published artifact references it`);
+    failed = true;
+  }
+
+  if (missing.length === 0 && unused.length === 0) {
+    const list = [...referenced.keys()].sort().join(', ') || 'none';
+    console.log(`  ✓ declarations match the artifacts (referenced: ${list})`);
+  }
+}
+
+if (failed) {
+  console.log(
+    '\n✖ package dependency check failed.' +
+      '\n  An undeclared import breaks a consumer install without breaking anything here —' +
+      '\n  this repo has every package hoisted, so it only surfaces in a clean install.' +
+      '\n  An unused runtime dependency is how a build tool ends up shipped to consumers.\n',
+  );
+  process.exit(1);
+}
+
+console.log('\n✓  published dependencies match the published artifacts\n');

--- a/src/web-components/components/tone-picker/candor-tone-picker.stories.ts
+++ b/src/web-components/components/tone-picker/candor-tone-picker.stories.ts
@@ -77,8 +77,9 @@ import { NAVY_GAMUT_ROWS, NAVY_GAMUT_HEADERS } from '@candor-design/web-componen
 \`\`\`
 
 For custom hues, use \`buildGamutRows\` — it accepts the raw L × C grid and the anchor coordinates, and
-returns a \`ToneRow[]\` with CIEDE2000 labels computed at build time (culori is a peer dependency of the
-\`/tone-data\` entry point and is not bundled into it):
+returns a \`ToneRow[]\` whose labels carry the CIEDE2000 distance from the anchor. culori computes those
+distances and is **not** bundled into the \`/tone-data\` entry, so the entry imports it at runtime; it is a
+declared \`dependency\` of \`@candor-design/web-components\` and needs no action from you (#254):
 
 \`\`\`ts
 import { buildGamutRows } from '@candor-design/web-components/tone-data';

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -46,6 +46,9 @@
     "access": "public",
     "provenance": true
   },
+  "dependencies": {
+    "culori": "^4.0.2"
+  },
   "peerDependencies": {
     "@candor-design/tokens": ">=4.0.0"
   }


### PR DESCRIPTION
Fixes #254. Two commits: the manifest fix, then the gate that would have caught it.

## The two bugs were cancelling out

`@candor-design/web-components` declared **no dependencies at all**, yet its `./tone-data` entry point ships a bare `import … from "culori"` (deliberately — `external: ['culori']`, so a consumer already using culori doesn't get a second copy). It resolved anyway, because `@candor-design/tokens` carried `culori` in *its* runtime dependencies, where it did not belong.

Proven by negative control in a clean directory:

```
$ rm -rf node_modules/culori
$ node --input-type=module -e "import('@candor-design/web-components/tone-data')"
FAILED: ERR_MODULE_NOT_FOUND - Cannot find package 'culori'
```

So **the obvious reading of #254 — "delete culori from tokens" — would have published a broken entry point.** Both halves are in the same commit.

## What changed

**`@candor-design/web-components`** declares `culori` as a `dependency`. Not an optional peer: npm doesn't auto-install those, so an optional peer plus the tokens removal would reproduce exactly the state being fixed on any clean install. A dependency costs install weight only — bundlers still include only what's imported.

Bundling culori instead was measured and rejected: `tone-data.js` goes **4.44 kB → 65.42 kB** (culori's colour-space machinery doesn't tree-shake), and `buildGamutRows` is an exported helper consumers call with their own data, so culori is needed either way.

**`@candor-design/tokens`** ships `files: ["tokens"]` — four CSS/JSON artifacts — and declared ten runtime dependencies:

| dep | action | why |
|---|---|---|
| 5 × `@fontsource*` | **kept** | `candor-fonts.css` `@import`s them by bare specifier |
| `typescript` | → `devDependencies` | it's the compiler |
| `lit` | → `devDependencies` | bundled into `web-components/dist`; the tokens artifact is CSS/JSON |
| `tslib` | → `devDependencies` | build-time only (`importHelpers`) |
| `@standard-schema/spec` | **removed** | its only occurrence anywhere in the repo was its own `package.json` line |
| `culori` | → `devDependencies` | still needed by `scripts/export-tokens-dtcg.js` and `gamut-data.ts` |

**Story prose corrected.** The tone-picker story made two false claims about this exact code: culori was "a peer dependency of the `/tone-data` entry point" (nothing declared such a peer) and the CIEDE2000 labels were "computed at build time" (`buildGamutRows` runs at module top level and computes them on import).

## Verification — by packing, not by reading

Both tarballs packed and installed in an empty directory:

```
+-- @candor-design/tokens@5.0.0
| +-- @fontsource-variable/noto-sans@5.3.0
| +-- @fontsource-variable/noto-serif@5.3.0
| +-- @fontsource-variable/roboto-flex@5.3.0
| +-- @fontsource-variable/roboto-mono@5.3.0
| `-- @fontsource/atkinson-hyperlegible@5.3.0
`-- @candor-design/web-components@5.0.0
  +-- @candor-design/tokens@5.0.0 deduped
  `-- culori@4.0.2
```

No compiler, no lit. `import '@candor-design/web-components/tone-data'` returns its 9 rows with labels intact (`ΔE 46 from anchor`). The main entry resolves and begins executing, then hits `HTMLElement is not defined` — expected, Lit components need a DOM and Node has none; resolution is what was being tested.

Also green: `typecheck`, `audit:tokens`, `audit:contrast` (no drift), `build:tokens`, `build:wc`, `test:playwright` 28/28, `npm audit` 0 vulnerabilities.

## The gate — `npm run audit:packaging`

#254's real finding was that **nothing read a manifest.** `build:tokens` validates the artifacts, `audit:*` validate colour, `typecheck` and `test:playwright` run against source. And `files` and `dependencies` were each individually plausible, so reading either by hand showed nothing wrong.

The new script compares bare specifiers in the published artifacts against what the manifest declares, in two directions:

- **undeclared** — in an artifact, not in any manifest. Breaks a consumer install, and **cannot fail locally**: this repo hoists everything into one `node_modules`, so it resolves here and surfaces only in a clean install elsewhere.
- **unused** — declared as a runtime dep, referenced by no artifact. Breaks nothing; it's how a compiler ends up in a stylesheet's dependency tree.

`peerDependencies` are exempt from the unused check — a peer is a claim about consumer coordination, not about what the bundle imports.

**Verified by tripwire in both directions:**

```
✖ undeclared: "culori" is imported by web-components/dist/tone-data.js but is not a dependency or peer
✖ unused: "typescript" is a runtime dependency but no published artifact references it
```

Both exit 1. It runs in `build-web-components` rather than `audit`, because it reads the gitignored `web-components/dist` and needs `build:wc` first — and that job is already a required check on both Node versions.

One implementation note worth flagging: block comments are stripped before scanning, and that isn't optional. `tokens/candor-tokens.css` opens with a usage example reading `@import url("candor-tokens.css")`, which the first version of the script dutifully reported as an undeclared dependency of the package on itself. Same shape as the `12px-ok:` marker rule — prose demonstrating a syntax must not be read as an instance of it.

No allowlist, per the `audit:tokens` precedent: inspection found no legitimate exception in either direction.

## Not addressed here

**Lit is bundled into `web-components/dist`** (234 kB) rather than externalized. That's why no `lit` declaration is needed, but it means a consumer who also uses Lit ships two copies, with the duplicate-registration warnings that implies. A deliberate design question, out of scope for a dependency-declaration fix — worth its own issue if you want it examined.
